### PR TITLE
feat: introduce distributed lock for several hosts

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -106,6 +106,8 @@ nuget Be.Vlaanderen.Basisregisters.BlobStore 2.2.2
 nuget Be.Vlaanderen.Basisregisters.Shaperon 7.7.0
 nuget Be.Vlaanderen.Basisregisters.Shaperon.Geometries 7.7.0
 
+nuget Be.Vlaanderen.Basisregisters.Aws.DistributedMutex 2.2.1
+
 // DOCS STUFF
 nuget Structurizr.Core 0.9.5
 nuget Structurizr.Client 0.9.5

--- a/src/RoadRegistry.BackOffice.Api/appsettings.json
+++ b/src/RoadRegistry.BackOffice.Api/appsettings.json
@@ -36,5 +36,9 @@
       "Application": "RoadRegistry - BackOffice Api",
       "ContainerId": "REPLACE_CONTAINERID"
     }
+  },
+  "DistributedLock":
+  {
+    "Enabled": false
   }
 }

--- a/src/RoadRegistry.BackOffice.CommandHost/appsettings.json
+++ b/src/RoadRegistry.BackOffice.CommandHost/appsettings.json
@@ -31,5 +31,9 @@
       "Application": "RoadRegistry - BackOffice Command Host",
       "ContainerId": "REPLACE_CONTAINERID"
     }
+  },
+  "DistributedLock":
+  {
+    "Enabled": false
   }
 }

--- a/src/RoadRegistry.BackOffice.CommandHost/paket.references
+++ b/src/RoadRegistry.BackOffice.CommandHost/paket.references
@@ -14,3 +14,5 @@ Serilog.Sinks.Console
 Serilog.Sinks.Seq
 
 System.Threading.Channels
+
+Be.Vlaanderen.Basisregisters.Aws.DistributedMutex

--- a/src/RoadRegistry.BackOffice.EventHost/appsettings.json
+++ b/src/RoadRegistry.BackOffice.EventHost/appsettings.json
@@ -32,5 +32,9 @@
       "Application": "RoadRegistry - BackOffice Event Host",
       "ContainerId": "REPLACE_CONTAINERID"
     }
+  },
+  "DistributedLock":
+  {
+    "Enabled": false
   }
 }

--- a/src/RoadRegistry.BackOffice.EventHost/paket.references
+++ b/src/RoadRegistry.BackOffice.EventHost/paket.references
@@ -14,3 +14,5 @@ Serilog.Sinks.Console
 Serilog.Sinks.Seq
 
 System.Threading.Channels
+
+Be.Vlaanderen.Basisregisters.Aws.DistributedMutex

--- a/src/RoadRegistry.BackOffice.ProjectionHost/appsettings.json
+++ b/src/RoadRegistry.BackOffice.ProjectionHost/appsettings.json
@@ -30,5 +30,9 @@
       "Application": "RoadRegistry - BackOffice Projection Host",
       "ContainerId": "REPLACE_CONTAINERID"
     }
+  },
+  "DistributedLock":
+  {
+    "Enabled": false
   }
 }

--- a/src/RoadRegistry.BackOffice.ProjectionHost/paket.references
+++ b/src/RoadRegistry.BackOffice.ProjectionHost/paket.references
@@ -20,3 +20,5 @@ Serilog.Sinks.Seq
 System.Threading.Channels
 
 Polly
+
+Be.Vlaanderen.Basisregisters.Aws.DistributedMutex

--- a/src/RoadRegistry.Legacy.Import/appsettings.json
+++ b/src/RoadRegistry.Legacy.Import/appsettings.json
@@ -25,5 +25,9 @@
       "Application": "RoadRegistry - Import Legacy",
       "ContainerId": "REPLACE_CONTAINERID"
     }
+  },
+  "DistributedLock":
+  {
+    "Enabled": false
   }
 }

--- a/src/RoadRegistry.Legacy.Import/paket.references
+++ b/src/RoadRegistry.Legacy.Import/paket.references
@@ -14,3 +14,4 @@ Serilog.Sinks.Console
 Serilog.Sinks.Seq
 
 Be.Vlaanderen.Basisregisters.DataDog.Tracing.Autofac
+Be.Vlaanderen.Basisregisters.Aws.DistributedMutex


### PR DESCRIPTION
This PR introduces support for a distributed lock (defaults to `false` for local development purposes) in the following hosts:

- api
- event host
- command host
- projection host
- import legacy (host)

For completeness sake:

- extract from legacy runs locally and does not need it
- ui can run multiple instances / versions in parallel