### PR TITLE
perf: improve projection performance

### DIFF
--- a/src/RoadRegistry.Editor.ProjectionHost/EventProcessor.cs
+++ b/src/RoadRegistry.Editor.ProjectionHost/EventProcessor.cs
@@ -111,6 +111,7 @@ namespace RoadRegistry.Editor.ProjectionHost
                                     var observedMessageCount = 0;
                                     var catchUpPosition = catchUp.AfterPosition ?? Position.Start;
                                     var context = dbContextFactory();
+                                    context.ChangeTracker.AutoDetectChangesEnabled = false;
                                     var page = await streamStore
                                         .ReadAllForwards(
                                             catchUpPosition,
@@ -157,10 +158,12 @@ namespace RoadRegistry.Editor.ProjectionHost
                                                         catchUpPosition,
                                                         _messagePumpCancellation.Token)
                                                     .ConfigureAwait(false);
+                                                context.ChangeTracker.DetectChanges();
                                                 await context.SaveChangesAsync(_messagePumpCancellation.Token).ConfigureAwait(false);
                                                 await context.DisposeAsync().ConfigureAwait(false);
 
                                                 context = dbContextFactory();
+                                                context.ChangeTracker.AutoDetectChangesEnabled = false;
                                                 observedMessageCount = 0;
                                             }
                                         }
@@ -179,6 +182,7 @@ namespace RoadRegistry.Editor.ProjectionHost
                                                 catchUpPosition,
                                                 _messagePumpCancellation.Token)
                                             .ConfigureAwait(false);
+                                        context.ChangeTracker.DetectChanges();
                                         await context.SaveChangesAsync(_messagePumpCancellation.Token).ConfigureAwait(false);
                                     }
 

--- a/src/RoadRegistry.Editor.Projections/RoadNetworkInfoProjection.cs
+++ b/src/RoadRegistry.Editor.Projections/RoadNetworkInfoProjection.cs
@@ -1,12 +1,10 @@
 ﻿namespace RoadRegistry.Editor.Projections
 {
-    using System.Linq;
     using BackOffice.Messages;
     using Be.Vlaanderen.Basisregisters.ProjectionHandling.Connector;
     using Be.Vlaanderen.Basisregisters.ProjectionHandling.SqlStreamStore;
     using Be.Vlaanderen.Basisregisters.Shaperon;
     using Be.Vlaanderen.Basisregisters.Shaperon.Geometries;
-    using Microsoft.EntityFrameworkCore;
     using Schema;
 
     public class RoadNetworkInfoProjection : ConnectedProjection<EditorContext>
@@ -18,14 +16,12 @@
             );
             When<Envelope<CompletedRoadNetworkImport>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 info.CompletedImport = true;
             });
             When<Envelope<ImportedRoadNode>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 info.RoadNodeCount += 1;
                 info.TotalRoadNodeShapeLength +=
                     new PointShapeContent(
@@ -36,8 +32,7 @@
             });
             When<Envelope<ImportedRoadSegment>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 info.RoadSegmentCount += 1;
                 info.TotalRoadSegmentShapeLength +=
                     new PolyLineMShapeContent(
@@ -54,21 +49,18 @@
             });
             When<Envelope<ImportedGradeSeparatedJunction>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 info.GradeSeparatedJunctionCount += 1;
             });
             When<Envelope<ImportedOrganization>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 info.OrganizationCount += 1;
             });
 
             When<Envelope<RoadNetworkChangesBasedOnArchiveAccepted>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 foreach (var change in envelope.Message.Changes.Flatten())
                 {
                     switch (change)

--- a/src/RoadRegistry.Editor.Schema/EditorContext.cs
+++ b/src/RoadRegistry.Editor.Schema/EditorContext.cs
@@ -1,5 +1,8 @@
 namespace RoadRegistry.Editor.Schema
 {
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Be.Vlaanderen.Basisregisters.ProjectionHandling.Runner;
     using GradeSeparatedJunctions;
     using Microsoft.EntityFrameworkCore;
@@ -9,6 +12,8 @@ namespace RoadRegistry.Editor.Schema
 
     public class EditorContext : RunnerDbContext<EditorContext>
     {
+        private RoadNetworkInfo _localRoadNetworkInfo;
+
         public override string ProjectionStateSchema => WellknownSchemas.EditorMetaSchema;
 
         public DbSet<RoadNodeRecord> RoadNodes { get; set; }
@@ -25,6 +30,13 @@ namespace RoadRegistry.Editor.Schema
         public DbSet<RoadNodeBoundingBox2D> RoadNodeBoundingBox { get; set; }
         public DbSet<RoadSegmentBoundingBox3D> RoadSegmentBoundingBox { get; set; }
         public DbSet<RoadNetworkChange> RoadNetworkChanges { get; set; }
+
+        public async ValueTask<RoadNetworkInfo> GetRoadNetworkInfo(CancellationToken token)
+        {
+            return _localRoadNetworkInfo ??=
+                RoadNetworkInfo.Local.SingleOrDefault() ??
+                await RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+        }
 
         public EditorContext() {}
 

--- a/src/RoadRegistry.Editor.Schema/EditorContext.cs
+++ b/src/RoadRegistry.Editor.Schema/EditorContext.cs
@@ -35,7 +35,7 @@ namespace RoadRegistry.Editor.Schema
         {
             return _localRoadNetworkInfo ??=
                 RoadNetworkInfo.Local.SingleOrDefault() ??
-                await RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                await RoadNetworkInfo.SingleAsync(candidate => candidate.Id == Schema.RoadNetworkInfo.Identifier, token);
         }
 
         public EditorContext() {}

--- a/src/RoadRegistry.Editor.Schema/RoadNetworkInfo.cs
+++ b/src/RoadRegistry.Editor.Schema/RoadNetworkInfo.cs
@@ -2,7 +2,9 @@
 {
     public class RoadNetworkInfo
     {
-        public int Id { get; set; } = 0;
+        public const int Identifier = 0;
+
+        public int Id { get; set; } = Identifier;
         public bool CompletedImport { get; set; }
         public int OrganizationCount { get; set; }
         public int RoadNodeCount { get; set; }

--- a/src/RoadRegistry.Editor.Schema/RoadNetworkInfoConfiguration.cs
+++ b/src/RoadRegistry.Editor.Schema/RoadNetworkInfoConfiguration.cs
@@ -13,7 +13,7 @@
                 .HasIndex(p => p.Id)
                 .IsClustered(false);
 
-            b.Property(p => p.Id).ValueGeneratedNever().HasDefaultValue(0).IsRequired();
+            b.Property(p => p.Id).ValueGeneratedNever().HasDefaultValue(RoadNetworkInfo.Identifier).IsRequired();
             b.Property(p => p.CompletedImport).HasDefaultValue(false).IsRequired();
             b.Property(p => p.OrganizationCount).HasDefaultValue(0).IsRequired();
             b.Property(p => p.RoadNodeCount).HasDefaultValue(0).IsRequired();

--- a/src/RoadRegistry.Product.ProjectionHost/EventProcessor.cs
+++ b/src/RoadRegistry.Product.ProjectionHost/EventProcessor.cs
@@ -111,6 +111,7 @@ namespace RoadRegistry.Product.ProjectionHost
                                     var observedMessageCount = 0;
                                     var catchUpPosition = catchUp.AfterPosition ?? Position.Start;
                                     var context = dbContextFactory();
+                                    context.ChangeTracker.AutoDetectChangesEnabled = false;
                                     var page = await streamStore
                                         .ReadAllForwards(
                                             catchUpPosition,
@@ -157,10 +158,12 @@ namespace RoadRegistry.Product.ProjectionHost
                                                         catchUpPosition,
                                                         _messagePumpCancellation.Token)
                                                     .ConfigureAwait(false);
+                                                context.ChangeTracker.DetectChanges();
                                                 await context.SaveChangesAsync(_messagePumpCancellation.Token).ConfigureAwait(false);
                                                 await context.DisposeAsync().ConfigureAwait(false);
 
                                                 context = dbContextFactory();
+                                                context.ChangeTracker.AutoDetectChangesEnabled = false;
                                                 observedMessageCount = 0;
                                             }
                                         }
@@ -179,6 +182,7 @@ namespace RoadRegistry.Product.ProjectionHost
                                                 catchUpPosition,
                                                 _messagePumpCancellation.Token)
                                             .ConfigureAwait(false);
+                                        context.ChangeTracker.DetectChanges();
                                         await context.SaveChangesAsync(_messagePumpCancellation.Token).ConfigureAwait(false);
                                     }
 

--- a/src/RoadRegistry.Product.Projections/RoadNetworkInfoProjection.cs
+++ b/src/RoadRegistry.Product.Projections/RoadNetworkInfoProjection.cs
@@ -1,12 +1,10 @@
 ﻿namespace RoadRegistry.Product.Projections
 {
-    using System.Linq;
     using BackOffice.Messages;
     using Be.Vlaanderen.Basisregisters.ProjectionHandling.Connector;
     using Be.Vlaanderen.Basisregisters.ProjectionHandling.SqlStreamStore;
     using Be.Vlaanderen.Basisregisters.Shaperon;
     using Be.Vlaanderen.Basisregisters.Shaperon.Geometries;
-    using Microsoft.EntityFrameworkCore;
     using Schema;
 
     public class RoadNetworkInfoProjection : ConnectedProjection<ProductContext>
@@ -18,14 +16,12 @@
             );
             When<Envelope<CompletedRoadNetworkImport>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 info.CompletedImport = true;
             });
             When<Envelope<ImportedRoadNode>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 info.RoadNodeCount += 1;
                 info.TotalRoadNodeShapeLength +=
                     new PointShapeContent(
@@ -36,8 +32,7 @@
             });
             When<Envelope<ImportedRoadSegment>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 info.RoadSegmentCount += 1;
                 info.TotalRoadSegmentShapeLength +=
                     new PolyLineMShapeContent(
@@ -54,21 +49,18 @@
             });
             When<Envelope<ImportedGradeSeparatedJunction>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 info.GradeSeparatedJunctionCount += 1;
             });
             When<Envelope<ImportedOrganization>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 info.OrganizationCount += 1;
             });
 
             When<Envelope<RoadNetworkChangesBasedOnArchiveAccepted>>(async (context, envelope, token) =>
             {
-                var info = context.RoadNetworkInfo.Local.SingleOrDefault() ??
-                           await context.RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                var info = await context.GetRoadNetworkInfo(token);
                 foreach (var change in envelope.Message.Changes.Flatten())
                 {
                     switch (change)

--- a/src/RoadRegistry.Product.Schema/ProductContext.cs
+++ b/src/RoadRegistry.Product.Schema/ProductContext.cs
@@ -35,7 +35,7 @@ namespace RoadRegistry.Product.Schema
         {
             return _localRoadNetworkInfo ??=
                 RoadNetworkInfo.Local.SingleOrDefault() ??
-                await RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+                await RoadNetworkInfo.SingleAsync(candidate => candidate.Id == Schema.RoadNetworkInfo.Identifier, token);
         }
 
         public ProductContext() {}

--- a/src/RoadRegistry.Product.Schema/ProductContext.cs
+++ b/src/RoadRegistry.Product.Schema/ProductContext.cs
@@ -1,5 +1,8 @@
 namespace RoadRegistry.Product.Schema
 {
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Be.Vlaanderen.Basisregisters.ProjectionHandling.Runner;
     using GradeSeparatedJunctions;
     using Microsoft.EntityFrameworkCore;
@@ -9,6 +12,8 @@ namespace RoadRegistry.Product.Schema
 
     public class ProductContext : RunnerDbContext<ProductContext>
     {
+        private RoadNetworkInfo _localRoadNetworkInfo;
+
         public override string ProjectionStateSchema => WellknownSchemas.ProductMetaSchema;
 
         public DbSet<RoadNodeRecord> RoadNodes { get; set; }
@@ -25,6 +30,13 @@ namespace RoadRegistry.Product.Schema
 
         public DbSet<RoadNodeBoundingBox2D> RoadNodeBoundingBox { get; set; }
         public DbSet<RoadSegmentBoundingBox3D> RoadSegmentBoundingBox { get; set; }
+
+        public async ValueTask<RoadNetworkInfo> GetRoadNetworkInfo(CancellationToken token)
+        {
+            return _localRoadNetworkInfo ??=
+                RoadNetworkInfo.Local.SingleOrDefault() ??
+                await RoadNetworkInfo.SingleAsync(candidate => candidate.Id == 0, token);
+        }
 
         public ProductContext() {}
 

--- a/src/RoadRegistry.Product.Schema/RoadNetworkInfo.cs
+++ b/src/RoadRegistry.Product.Schema/RoadNetworkInfo.cs
@@ -2,7 +2,8 @@
 {
     public class RoadNetworkInfo
     {
-        public int Id { get; set; } = 0;
+        public const int Identifier = 0;
+        public int Id { get; set; } = Identifier;
         public bool CompletedImport { get; set; }
         public int OrganizationCount { get; set; }
         public int RoadNodeCount { get; set; }

--- a/src/RoadRegistry.Product.Schema/RoadNetworkInfoConfiguration.cs
+++ b/src/RoadRegistry.Product.Schema/RoadNetworkInfoConfiguration.cs
@@ -13,7 +13,7 @@
                 .HasIndex(p => p.Id)
                 .IsClustered(false);
 
-            b.Property(p => p.Id).ValueGeneratedNever().HasDefaultValue(0).IsRequired();
+            b.Property(p => p.Id).ValueGeneratedNever().HasDefaultValue(RoadNetworkInfo.Identifier).IsRequired();
             b.Property(p => p.CompletedImport).HasDefaultValue(false).IsRequired();
             b.Property(p => p.OrganizationCount).HasDefaultValue(0).IsRequired();
             b.Property(p => p.RoadNodeCount).HasDefaultValue(0).IsRequired();


### PR DESCRIPTION
This PR improves the performance of the various road registry projections by eagerly caching the road network info and by disabling automatic change detection (using manual change detection instead) while in catchup mode. Both for editor and product projections.