### PR TITLE
feat: explicit provisional change handling

### DIFF
--- a/docs/adr/005-etl.md
+++ b/docs/adr/005-etl.md
@@ -1,0 +1,23 @@
+# 5. ETL
+
+Date: 2021-04-01
+
+## Status
+
+Accepted
+
+## Context
+
+The road registry existed before this version of the software that operates on it. We can't expect operators to start from scratch and redraw every node and segment.
+
+## Decision
+
+We extract the necessary road registry data, in the form of events, from its _legacy_ database, using a tool aptly named `RoadRegistry.Legacy.Extract`. This tools takes a connection string to the legacy database and transforms some of the tables and rows into a very long list of events, each time noting which stream the event will need to go into as well as the event itself (effectively a `(stream, event)` tuple), putting those into a file called `streams.json` (looks like a very big json array) and compresses that file in turn into a `import-streams.zip` file. This file can then be uploaded to an appropriate AWS S3 Bucket (see the AWS Infrastructure repository to determine which one it is in production), either via the tool itself (if you configure it accordingly) or via the AWS CLI.
+
+The reason for disconnecting the extraction and loading from each other via a file is because the legacy database is usually running on premises or in a different cloud (Azure, in case of the legacy road registry) or a developer's machine, but not in the AWS environment. To avoid putting in extra infrastructure for what is essentially going to be a once in a lifetime job, putting AWS S3 between the extraction and loading seemed like a reasonable trade off.
+
+The loading of the extracted events is done via a tool named `RoadRegistry.Legacy.Import`, which takes the uploaded file from an AWS S3 Bucket and a connection string to the road registry event store (probably an RDS instance running in AWS) and appends the events contained in the uploaded file to their respective streams. The order in which the `(stream, event)` tuples appear in the file is the order in which they will be appended to the mentioned stream.
+
+## Consequences
+
+This way the operator can start off from a well known state of the road registry and start uploading future changes. Once this process is deemed stable and production worthy, the mentioned ETL tooling can be removed from both the infrastructure and the codebase.

--- a/docs/adr/006-provisional-changes.md
+++ b/docs/adr/006-provisional-changes.md
@@ -1,0 +1,23 @@
+# 5. ETL
+
+Date: 2021-04-01
+
+## Status
+
+Accepted
+
+## Context
+
+As a result of running the feature-compare process a bunch of files are produced. These files are essentially a _diff_ between what the operator started out with, that is the dump / extract he / she started working from, and what they ended up with, after having edited shapes and associated data in their editor. Some of those files have a `_ALL.DBF|_ALL.SHP` suffix. These files are the files we base our logic on to validate and translate to an _internal_ change request. Most notably, these files have an extra column called `RECORDTYPE` which, as the name suggests, classifies a record as either being `IDENTICAL`, `ADDED`, `MODIFIED` or `REMOVED`. Next to that most of the files contain, per record, the equivalent of a primary key that identifies a row. This primary key is used in other files as a foreign key to reference a record sitting in another file. Records with a `RECORDTYPE` of `ADDED` will use a temporary identifier (a really big number that we assume is free to use) to make this work (see [004-temporary-and-permanent-identifiers.md](004-temporary-and-permanent-identifiers.md) for how that works). One gotcha is that the primary keys are not always unique, that is, they can appear multiple times in the `*_ALL.DBF|*_ALL.SHP` files, once for each record type. A common scenario is a modification represented as a removal and an addition record.
+
+For the `WEGSEGMENT_ALL.DBF` file, things are more complicated ... next to having a `WS_OIDN` column act as primary key it has a `EVENTIDN` column acting as an alternative primary key in some cases. In case the `RECORDTYPE` is `ADDED` and the `EVENTIDN` has a value differing from `0`, the `WS_OIDN` column refers to an existing road segment and the `EVENTIDN` column refers to its new representation. In such a case, other files refer to a road segment by the value found in the `EVENTIDN`, not by the value in `WS_OIDN`. Alas, such is life ...
+
+## Decision
+
+Modifying a road segment involves data from `WEGSEGMENT_ALL.DBF`, `WEGSEGMENT_ALL.SHP` and `ATTRIJSTROKEN_ALL.DBF`, `ATTWEGBREEDTE_ALL.DBF`, `ATTWEGVERHARDING_ALL.DBF` - that is, when it is represented as an _internal_ change request command. Each of those `.DBF` files contains a `RECORDTYPE` column. As such, a road segment could be marked as identical in `WEGSEGMENT_ALL.DB`, yet it's lanes, width and / or surfaces could be marked as a mixture of modified, removed, added, identical. This is the reason why a road segment that is identical is appended as a `provisional` change to the list of translated changes. Because we're not sure, just yet, that it is an actual change. The order in which these files are translated causes a `provisional` change, if warranted, to be promoted to an actual change.
+
+Why go thru all this trouble? Well, lanes, widths, and surfaces are tightly coupled to the geometry of a road segment such that it makes sense to capture them as a holistic change rather than as individual fragmented changes. There's still a bigger debate to be had about which pieces of data change together ...
+
+## Consequences
+
+This behavior matches the operator's mental model.

--- a/src/RoadRegistry.BackOffice/Core/RoadNetworkEventModule.cs
+++ b/src/RoadRegistry.BackOffice/Core/RoadNetworkEventModule.cs
@@ -24,13 +24,13 @@ namespace RoadRegistry.BackOffice.Core
                     await snapshotWriter.WriteSnapshot(network.TakeSnapshot(), version, ct);
                 });
 
-            // For<RoadNetworkChangesAccepted>()
-            //     .UseRoadRegistryContext(store, snapshotReader, EnrichEvent.WithTime(clock))
-            //     .Handle(async (context, message, ct) =>
-            //     {
-            //         var (network, version) = await context.RoadNetworks.GetWithVersion(ct);
-            //         await snapshotWriter.WriteSnapshot(network.TakeSnapshot(), version, ct);
-            //     });
+            For<RoadNetworkChangesAccepted>()
+                .UseRoadRegistryContext(store, snapshotReader, EnrichEvent.WithTime(clock))
+                .Handle(async (context, message, ct) =>
+                {
+                    var (network, version) = await context.RoadNetworks.GetWithVersion(ct);
+                    await snapshotWriter.WriteSnapshot(network.TakeSnapshot(), version, ct);
+                });
         }
     }
 }

--- a/src/RoadRegistry.BackOffice/Uploads/RoadSegmentChangeShapeRecordsTranslator.cs
+++ b/src/RoadRegistry.BackOffice/Uploads/RoadSegmentChangeShapeRecordsTranslator.cs
@@ -18,9 +18,20 @@ namespace RoadRegistry.BackOffice.Uploads
                 var record = records.Current;
                 if (record != null && record.Content is PolyLineMShapeContent content)
                 {
-                    if (changes.TryFindRoadSegmentChangeOfShapeRecord(record.Header.RecordNumber, out var change))
+                    var geometry = GeometryTranslator.ToGeometryMultiLineString(content.Shape);
+                    if (changes.TryFindRoadSegmentProvisionalChange(record.Header.RecordNumber,
+                        out var provisionalChange))
                     {
-                        var geometry = GeometryTranslator.ToGeometryMultiLineString(content.Shape);
+                        switch (provisionalChange)
+                        {
+                            case ModifyRoadSegment modifyRoadSegment:
+                                changes = changes.ReplaceProvisionalChange(modifyRoadSegment, modifyRoadSegment.WithGeometry(geometry));
+                                break;
+                        }
+                    }
+                    else if (changes.TryFindRoadSegmentChange(record.Header.RecordNumber, out var change))
+                    {
+
                         switch (change)
                         {
                             case AddRoadSegment addRoadSegment:

--- a/src/RoadRegistry.BackOffice/Uploads/RoadSegmentSurfaceChangeDbaseRecordsTranslator.cs
+++ b/src/RoadRegistry.BackOffice/Uploads/RoadSegmentSurfaceChangeDbaseRecordsTranslator.cs
@@ -18,19 +18,42 @@ namespace RoadRegistry.BackOffice.Uploads
                 var record = records.Current;
                 if (record != null)
                 {
-                    switch (record.RECORDTYPE.Value)
+                    var segmentId = new RoadSegmentId(record.WS_OIDN.Value);
+                    var surface = new RoadSegmentSurfaceAttribute(
+                        new AttributeId(record.WV_OIDN.Value),
+                        RoadSegmentSurfaceType.ByIdentifier[record.TYPE.Value],
+                        RoadSegmentPosition.FromDouble(record.VANPOSITIE.Value),
+                        RoadSegmentPosition.FromDouble(record.TOTPOSITIE.Value)
+                    );
+                    if (changes.TryFindRoadSegmentProvisionalChange(segmentId, out var provisionalChange))
                     {
-                        case RecordType.IdenticalIdentifier:
-                        case RecordType.AddedIdentifier:
-                            var segmentId = new RoadSegmentId(record.WS_OIDN.Value);
-                            if (changes.TryFindRoadSegmentChangeOfDynamicAttributeRecord(segmentId, out var change))
-                            {
-                                var surface = new RoadSegmentSurfaceAttribute(
-                                    new AttributeId(record.WV_OIDN.Value),
-                                    RoadSegmentSurfaceType.ByIdentifier[record.TYPE.Value],
-                                    RoadSegmentPosition.FromDouble(record.VANPOSITIE.Value),
-                                    RoadSegmentPosition.FromDouble(record.TOTPOSITIE.Value)
-                                );
+                        switch (provisionalChange)
+                        {
+                            case ModifyRoadSegment modifyRoadSegment:
+                                switch (record.RECORDTYPE.Value)
+                                {
+                                    case RecordType.IdenticalIdentifier:
+                                        changes = changes.ReplaceProvisionalChange(modifyRoadSegment,
+                                            modifyRoadSegment.WithSurface(surface));
+                                        break;
+                                    case RecordType.AddedIdentifier:
+                                    case RecordType.ModifiedIdentifier:
+                                        changes = changes.ReplaceChange(modifyRoadSegment,
+                                            modifyRoadSegment.WithSurface(surface));
+                                        break;
+                                    case RecordType.RemovedIdentifier:
+                                        changes = changes.ReplaceChange(modifyRoadSegment, modifyRoadSegment);
+                                        break;
+                                }
+                                break;
+                        }
+                    }
+                    else if (changes.TryFindRoadSegmentChange(segmentId, out var change))
+                    {
+                        switch (record.RECORDTYPE.Value)
+                        {
+                            case RecordType.IdenticalIdentifier:
+                            case RecordType.AddedIdentifier:
                                 switch (change)
                                 {
                                     case AddRoadSegment addRoadSegment:
@@ -40,8 +63,8 @@ namespace RoadRegistry.BackOffice.Uploads
                                         changes = changes.ReplaceChange(modifyRoadSegment, modifyRoadSegment.WithSurface(surface));
                                         break;
                                 }
-                            }
-                            break;
+                                break;
+                        }
                     }
                 }
             }

--- a/src/RoadRegistry.BackOffice/Uploads/RoadSegmentWidthChangeDbaseRecordsTranslator.cs
+++ b/src/RoadRegistry.BackOffice/Uploads/RoadSegmentWidthChangeDbaseRecordsTranslator.cs
@@ -18,19 +18,42 @@ namespace RoadRegistry.BackOffice.Uploads
                 var record = records.Current;
                 if (record != null)
                 {
-                    switch (record.RECORDTYPE.Value)
+                    var segmentId = new RoadSegmentId(record.WS_OIDN.Value);
+                    var width = new RoadSegmentWidthAttribute(
+                        new AttributeId(record.WB_OIDN.Value),
+                        new RoadSegmentWidth(record.BREEDTE.Value),
+                        RoadSegmentPosition.FromDouble(record.VANPOSITIE.Value),
+                        RoadSegmentPosition.FromDouble(record.TOTPOSITIE.Value)
+                    );
+                    if (changes.TryFindRoadSegmentProvisionalChange(segmentId, out var provisionalChange))
                     {
-                        case RecordType.IdenticalIdentifier:
-                        case RecordType.AddedIdentifier:
-                            var segmentId = new RoadSegmentId(record.WS_OIDN.Value);
-                            if (changes.TryFindRoadSegmentChangeOfDynamicAttributeRecord(segmentId, out var change))
-                            {
-                                var width = new RoadSegmentWidthAttribute(
-                                    new AttributeId(record.WB_OIDN.Value),
-                                    new RoadSegmentWidth(record.BREEDTE.Value),
-                                    RoadSegmentPosition.FromDouble(record.VANPOSITIE.Value),
-                                    RoadSegmentPosition.FromDouble(record.TOTPOSITIE.Value)
-                                );
+                        switch (provisionalChange)
+                        {
+                            case ModifyRoadSegment modifyRoadSegment:
+                                switch (record.RECORDTYPE.Value)
+                                {
+                                    case RecordType.IdenticalIdentifier:
+                                        changes = changes.ReplaceProvisionalChange(modifyRoadSegment,
+                                            modifyRoadSegment.WithWidth(width));
+                                        break;
+                                    case RecordType.AddedIdentifier:
+                                    case RecordType.ModifiedIdentifier:
+                                        changes = changes.ReplaceChange(modifyRoadSegment,
+                                            modifyRoadSegment.WithWidth(width));
+                                        break;
+                                    case RecordType.RemovedIdentifier:
+                                        changes = changes.ReplaceChange(modifyRoadSegment, modifyRoadSegment);
+                                        break;
+                                }
+                                break;
+                        }
+                    }
+                    else if (changes.TryFindRoadSegmentChange(segmentId, out var change))
+                    {
+                        switch (record.RECORDTYPE.Value)
+                        {
+                            case RecordType.IdenticalIdentifier:
+                            case RecordType.AddedIdentifier:
                                 switch (change)
                                 {
                                     case AddRoadSegment addRoadSegment:
@@ -40,8 +63,8 @@ namespace RoadRegistry.BackOffice.Uploads
                                         changes = changes.ReplaceChange(modifyRoadSegment, modifyRoadSegment.WithWidth(width));
                                         break;
                                 }
-                            }
-                            break;
+                                break;
+                        }
                     }
                 }
             }

--- a/test/RoadRegistry.Tests/BackOffice/Uploads/RoadSegmentChangeDbaseRecordsTranslatorTests.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Uploads/RoadSegmentChangeDbaseRecordsTranslatorTests.cs
@@ -206,7 +206,7 @@ namespace RoadRegistry.BackOffice.Uploads
             foreach (var current in records)
             {
                 var id = new RoadSegmentId(current.WS_OIDN.Value);
-                Assert.True(result.TryFindRoadSegmentChangeOfDynamicAttributeRecord(id, out var foundChange));
+                Assert.True(result.TryFindRoadSegmentProvisionalChange(id, out var foundChange));
                 Assert.NotNull(foundChange);
                 var actual = Assert.IsAssignableFrom<ITranslatedChange>(foundChange);
                 ITranslatedChange expected = new Uploads.ModifyRoadSegment(

--- a/test/RoadRegistry.Tests/BackOffice/Uploads/RoadSegmentChangeShapeRecordsTranslatorTests.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Uploads/RoadSegmentChangeShapeRecordsTranslatorTests.cs
@@ -129,6 +129,30 @@ namespace RoadRegistry.BackOffice.Uploads
         }
 
         [Fact]
+        public void TranslateWithIdenticalRecordsReturnsExpectedResult()
+        {
+            var segment = _fixture.Create<ModifyRoadSegment>();
+            var record = _fixture.Create<ShapeRecord>().Content.RecordAs(segment.RecordNumber);
+            var records = new List<ShapeRecord> { record };
+            var enumerator = records.GetEnumerator();
+            var changes = TranslatedChanges.Empty.AppendProvisionalChange(segment);
+
+            var result = _sut.Translate(_entry, enumerator, changes);
+
+            var expected = segment.WithGeometry(
+                GeometryTranslator.ToGeometryMultiLineString(
+                    ((PolyLineMShapeContent) record.Content).Shape)
+            );
+            var expectedResult = TranslatedChanges.Empty.AppendProvisionalChange(
+                expected
+            );
+
+            Assert.Equal(expectedResult,result, new TranslatedChangeEqualityComparer());
+            Assert.True(result.TryFindRoadSegmentProvisionalChange(segment.Id, out var actual));
+            Assert.Equal(expected, actual, new TranslatedChangeEqualityComparer());
+        }
+
+        [Fact]
         public void TranslateWithModifyRecordsReturnsExpectedResult()
         {
             var segment = _fixture.Create<ModifyRoadSegment>();

--- a/test/RoadRegistry.Tests/BackOffice/Uploads/RoadSegmentLaneChangeDbaseRecordsTranslatorTests.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Uploads/RoadSegmentLaneChangeDbaseRecordsTranslatorTests.cs
@@ -131,6 +131,91 @@ namespace RoadRegistry.BackOffice.Uploads
         }
 
         [Fact]
+        public void TranslateWithIdenticalRecordsForModifyRoadSegmentReturnsExpectedResult()
+        {
+            var segment = _fixture.Create<Uploads.ModifyRoadSegment>();
+            var records = _fixture
+                .CreateMany<RoadSegmentLaneChangeDbaseRecord>(new Random().Next(1, 5))
+                .Select((record, index) =>
+                {
+                    record.RS_OIDN.Value = index + 1;
+                    record.WS_OIDN.Value = segment.Id;
+                    record.TOTPOSITIE.Value = record.VANPOSITIE.Value + 1.0;
+                    record.RECORDTYPE.Value = RecordType.IdenticalIdentifier;
+                    return record;
+                })
+                .ToArray();
+            var enumerator = records.ToDbaseRecordEnumerator();
+            var changes = TranslatedChanges.Empty.AppendProvisionalChange(segment);
+
+            var result = _sut.Translate(_entry, enumerator, changes);
+
+            var expected = records
+                .Where(record => record.RECORDTYPE.Value != (short)RecordType.Removed.Translation.Identifier)
+                .Aggregate(
+                    segment,
+                    (current, record) => current.WithLane(
+                        new Uploads.RoadSegmentLaneAttribute(
+                            new AttributeId(record.RS_OIDN.Value),
+                            new RoadSegmentLaneCount(record.AANTAL.Value),
+                            RoadSegmentLaneDirection.ByIdentifier[record.RICHTING.Value],
+                            new RoadSegmentPosition(Convert.ToDecimal(record.VANPOSITIE.Value)),
+                            new RoadSegmentPosition(Convert.ToDecimal(record.TOTPOSITIE.Value)))
+                    )
+                );
+            var expectedResult = TranslatedChanges.Empty.AppendProvisionalChange(expected);
+
+            Assert.Equal(expectedResult,result, new TranslatedChangeEqualityComparer());
+
+            Assert.True(result.TryFindRoadSegmentProvisionalChange(segment.Id, out var actual));
+            Assert.Equal(expected, actual, new TranslatedChangeEqualityComparer());
+        }
+
+        [Fact]
+        public void TranslateWithChangedRecordsForModifyRoadSegmentReturnsExpectedResult()
+        {
+            var segment = _fixture.Create<Uploads.ModifyRoadSegment>();
+            var records = _fixture
+                .CreateMany<RoadSegmentLaneChangeDbaseRecord>(new Random().Next(1, 5))
+                .Select((record, index) =>
+                {
+                    record.RS_OIDN.Value = index + 1;
+                    record.WS_OIDN.Value = segment.Id;
+                    record.TOTPOSITIE.Value = record.VANPOSITIE.Value + 1.0;
+                    if (index == 0) // force at least one lane change to promote the provisional change to an actual change
+                    {
+                        record.RECORDTYPE.Value = RecordType.AddedIdentifier;
+                    }
+
+                    return record;
+                })
+                .ToArray();
+            var enumerator = records.ToDbaseRecordEnumerator();
+            var changes = TranslatedChanges.Empty.AppendProvisionalChange(segment);
+
+            var result = _sut.Translate(_entry, enumerator, changes);
+
+            var expected =
+                TranslatedChanges.Empty.AppendChange(
+                    records
+                        .Where(record => record.RECORDTYPE.Value != (short)RecordType.Removed.Translation.Identifier)
+                        .Aggregate(
+                            segment,
+                            (current, record) => current.WithLane(
+                                new Uploads.RoadSegmentLaneAttribute(
+                                    new AttributeId(record.RS_OIDN.Value),
+                                    new RoadSegmentLaneCount(record.AANTAL.Value),
+                                    RoadSegmentLaneDirection.ByIdentifier[record.RICHTING.Value],
+                                    new RoadSegmentPosition(Convert.ToDecimal(record.VANPOSITIE.Value)),
+                                    new RoadSegmentPosition(Convert.ToDecimal(record.TOTPOSITIE.Value)))
+                            )
+                        )
+                );
+
+            Assert.Equal(expected,result, new TranslatedChangeEqualityComparer());
+        }
+
+        [Fact]
         public void TranslateWithRecordsForRemovedRoadSegmentReturnsExpectedResult()
         {
             var segment = _fixture.Create<Uploads.RemoveRoadSegment>();

--- a/test/RoadRegistry.Tests/BackOffice/Uploads/RoadSegmentWidthChangeDbaseRecordsTranslatorTests.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Uploads/RoadSegmentWidthChangeDbaseRecordsTranslatorTests.cs
@@ -128,6 +128,90 @@ namespace RoadRegistry.BackOffice.Uploads
             Assert.Equal(expected,result, new TranslatedChangeEqualityComparer());
         }
 
+
+        [Fact]
+        public void TranslateWithIdenticalRecordsForModifyRoadSegmentReturnsExpectedResult()
+        {
+            var segment = _fixture.Create<Uploads.ModifyRoadSegment>();
+            var records = _fixture
+                .CreateMany<RoadSegmentWidthChangeDbaseRecord>(new Random().Next(1, 5))
+                .Select((record, index) =>
+                {
+                    record.WB_OIDN.Value = index + 1;
+                    record.WS_OIDN.Value = segment.Id;
+                    record.TOTPOSITIE.Value = record.VANPOSITIE.Value + 1.0;
+                    record.RECORDTYPE.Value = RecordType.IdenticalIdentifier;
+                    return record;
+                })
+                .ToArray();
+            var enumerator = records.ToDbaseRecordEnumerator();
+            var changes = TranslatedChanges.Empty.AppendProvisionalChange(segment);
+
+            var result = _sut.Translate(_entry, enumerator, changes);
+
+            var expected = records
+                .Where(record => record.RECORDTYPE.Value != (short)RecordType.Removed.Translation.Identifier)
+                .Aggregate(
+                    segment,
+                    (current, record) => current.WithWidth(
+                        new Uploads.RoadSegmentWidthAttribute(
+                            new AttributeId(record.WB_OIDN.Value),
+                            new RoadSegmentWidth(record.BREEDTE.Value),
+                            new RoadSegmentPosition(Convert.ToDecimal(record.VANPOSITIE.Value)),
+                            new RoadSegmentPosition(Convert.ToDecimal(record.TOTPOSITIE.Value)))
+                    )
+                );
+            var expectedResult = TranslatedChanges.Empty.AppendProvisionalChange(expected);
+
+            Assert.Equal(expectedResult,result, new TranslatedChangeEqualityComparer());
+
+            Assert.True(result.TryFindRoadSegmentProvisionalChange(segment.Id, out var actual));
+            Assert.Equal(expected, actual, new TranslatedChangeEqualityComparer());
+        }
+
+        [Fact]
+        public void TranslateWithChangedRecordsForModifyRoadSegmentReturnsExpectedResult()
+        {
+            var segment = _fixture.Create<Uploads.ModifyRoadSegment>();
+            var records = _fixture
+                .CreateMany<RoadSegmentWidthChangeDbaseRecord>(new Random().Next(1, 5))
+                .Select((record, index) =>
+                {
+                    record.WB_OIDN.Value = index + 1;
+                    record.WS_OIDN.Value = segment.Id;
+                    record.TOTPOSITIE.Value = record.VANPOSITIE.Value + 1.0;
+                    if (index == 0) // force at least one lane change to promote the provisional change to an actual change
+                    {
+                        record.RECORDTYPE.Value = RecordType.AddedIdentifier;
+                    }
+
+                    return record;
+                })
+                .ToArray();
+            var enumerator = records.ToDbaseRecordEnumerator();
+            var changes = TranslatedChanges.Empty.AppendProvisionalChange(segment);
+
+            var result = _sut.Translate(_entry, enumerator, changes);
+
+            var expected =
+                TranslatedChanges.Empty.AppendChange(
+                    records
+                        .Where(record => record.RECORDTYPE.Value != (short)RecordType.Removed.Translation.Identifier)
+                        .Aggregate(
+                            segment,
+                            (current, record) => current.WithWidth(
+                                new Uploads.RoadSegmentWidthAttribute(
+                                    new AttributeId(record.WB_OIDN.Value),
+                                    new RoadSegmentWidth(record.BREEDTE.Value),
+                                    new RoadSegmentPosition(Convert.ToDecimal(record.VANPOSITIE.Value)),
+                                    new RoadSegmentPosition(Convert.ToDecimal(record.TOTPOSITIE.Value)))
+                            )
+                        )
+                );
+
+            Assert.Equal(expected,result, new TranslatedChangeEqualityComparer());
+        }
+
         [Fact]
         public void TranslateWithRecordsForModifyRoadSegmentReturnsExpectedResult()
         {


### PR DESCRIPTION
This PR improves / fixes the usage of provisional changes (only road segment modifications qualify). The lane, width, surface translation logic was flawed in that identical lane / width / surface records caused provisional changes to become actual changes even when there was no cause to do so. The code now handles this scenario more explicitly (and has a few tests that cover this specific situation).

This PR also causes, upon accepting changes, additional snapshots to be created.