### PR TITLE
feat: improved road node type checking

### DIFF
--- a/src/RoadRegistry.BackOffice/Core/AddRoadSegment.cs
+++ b/src/RoadRegistry.BackOffice/Core/AddRoadSegment.cs
@@ -303,6 +303,7 @@ namespace RoadRegistry.BackOffice.Core
             }
             else
             {
+                problems = problems.AddRange(startNode.VerifyTypeMatchesConnectedSegmentCount(context.AfterView.View, context.Translator));
                 if (line.StartPoint != null && !line.StartPoint.EqualsWithinTolerance(startNode.Geometry, context.Tolerances.GeometryTolerance))
                 {
                     problems = problems.Add(new RoadSegmentStartPointDoesNotMatchNodeGeometry());
@@ -315,6 +316,7 @@ namespace RoadRegistry.BackOffice.Core
             }
             else
             {
+                problems = problems.AddRange(endNode.VerifyTypeMatchesConnectedSegmentCount(context.AfterView.View, context.Translator));
                 if (line.EndPoint != null && !line.EndPoint.EqualsWithinTolerance(endNode.Geometry, context.Tolerances.GeometryTolerance))
                 {
                     problems = problems.Add(new RoadSegmentEndPointDoesNotMatchNodeGeometry());

--- a/src/RoadRegistry.BackOffice/Core/ImmutableRoadNetworkView.cs
+++ b/src/RoadRegistry.BackOffice/Core/ImmutableRoadNetworkView.cs
@@ -1015,10 +1015,10 @@ namespace RoadRegistry.BackOffice.Core
 
             return new ImmutableRoadNetworkView(
                 _nodes
-                    .TryReplace(command.StartNodeId, node => node.ConnectWith(command.Id))
-                    .TryReplace(command.EndNodeId, node => node.ConnectWith(command.Id))
                     .TryReplaceIf(segmentBefore.Start, node => node.Id != command.StartNodeId, node => node.DisconnectFrom(command.Id))
-                    .TryReplaceIf(segmentBefore.End, node => node.Id != command.EndNodeId, node => node.DisconnectFrom(command.Id)),
+                    .TryReplaceIf(segmentBefore.End, node => node.Id != command.EndNodeId, node => node.DisconnectFrom(command.Id))
+                    .TryReplace(command.StartNodeId, node => node.ConnectWith(command.Id))
+                    .TryReplace(command.EndNodeId, node => node.ConnectWith(command.Id)),
                 _segments.
                     TryReplace(command.Id, segment => segment
                         .WithGeometry(command.Geometry)
@@ -2113,10 +2113,10 @@ namespace RoadRegistry.BackOffice.Core
                 var segmentBefore = _segments[command.Id];
 
                 _nodes
-                    .TryReplace(command.StartNodeId, node => node.ConnectWith(command.Id))
-                    .TryReplace(command.EndNodeId, node => node.ConnectWith(command.Id))
                     .TryReplaceIf(segmentBefore.Start, node => node.Id != command.StartNodeId, node => node.DisconnectFrom(command.Id))
-                    .TryReplaceIf(segmentBefore.End, node => node.Id != command.EndNodeId, node => node.DisconnectFrom(command.Id));
+                    .TryReplaceIf(segmentBefore.End, node => node.Id != command.EndNodeId, node => node.DisconnectFrom(command.Id))
+                    .TryReplace(command.StartNodeId, node => node.ConnectWith(command.Id))
+                    .TryReplace(command.EndNodeId, node => node.ConnectWith(command.Id));
                 _segments.TryReplace(command.Id, segment =>
                     segment
                         .WithGeometry(command.Geometry)

--- a/src/RoadRegistry.BackOffice/Core/ModifyRoadSegment.cs
+++ b/src/RoadRegistry.BackOffice/Core/ModifyRoadSegment.cs
@@ -306,13 +306,15 @@ namespace RoadRegistry.BackOffice.Core
 
             var segmentBefore = context.BeforeView.Segments[Id];
 
-            if (segmentBefore.Start != StartNodeId && context.AfterView.Nodes.TryGetValue(segmentBefore.Start, out var beforeStartNode))
+            if (segmentBefore.Start != StartNodeId && segmentBefore.Start != EndNodeId &&
+                context.AfterView.Nodes.TryGetValue(segmentBefore.Start, out var beforeStartNode))
             {
                 problems = problems.AddRange(
                     beforeStartNode.VerifyTypeMatchesConnectedSegmentCount(context.AfterView.View, context.Translator));
             }
 
-            if (segmentBefore.End != EndNodeId && context.AfterView.Nodes.TryGetValue(segmentBefore.End, out var beforeEndNode))
+            if (segmentBefore.End != StartNodeId && segmentBefore.End != EndNodeId &&
+                context.AfterView.Nodes.TryGetValue(segmentBefore.End, out var beforeEndNode))
             {
                 problems = problems.AddRange(
                     beforeEndNode.VerifyTypeMatchesConnectedSegmentCount(context.AfterView.View, context.Translator));
@@ -324,6 +326,7 @@ namespace RoadRegistry.BackOffice.Core
             }
             else
             {
+                problems = problems.AddRange(startNode.VerifyTypeMatchesConnectedSegmentCount(context.AfterView.View, context.Translator));
                 if (line.StartPoint != null && !line.StartPoint.EqualsWithinTolerance(startNode.Geometry, context.Tolerances.GeometryTolerance))
                 {
                     problems = problems.Add(new RoadSegmentStartPointDoesNotMatchNodeGeometry());
@@ -336,6 +339,7 @@ namespace RoadRegistry.BackOffice.Core
             }
             else
             {
+                problems = problems.AddRange(endNode.VerifyTypeMatchesConnectedSegmentCount(context.AfterView.View, context.Translator));
                 if (line.EndPoint != null && !line.EndPoint.EqualsWithinTolerance(endNode.Geometry, context.Tolerances.GeometryTolerance))
                 {
                     problems = problems.Add(new RoadSegmentEndPointDoesNotMatchNodeGeometry());

--- a/src/RoadRegistry.BackOffice/Core/RemoveRoadNode.cs
+++ b/src/RoadRegistry.BackOffice/Core/RemoveRoadNode.cs
@@ -30,7 +30,27 @@ namespace RoadRegistry.BackOffice.Core
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            return Problems.None;
+            var problems = Problems.None;
+
+            var nodeBefore = context.BeforeView.Nodes[Id];
+
+            foreach (var segment in nodeBefore.Segments)
+            {
+                if (context.AfterView.View.Segments.TryGetValue(segment, out var foundSegment))
+                {
+                    if (foundSegment.Start == Id)
+                    {
+                        problems = problems.Add(new RoadSegmentStartNodeRefersToRemovedNode(foundSegment.Id, Id));
+                    }
+
+                    if (foundSegment.End == Id)
+                    {
+                        problems = problems.Add(new RoadSegmentEndNodeRefersToRemovedNode(foundSegment.Id, Id));
+                    }
+                }
+            }
+
+            return problems;
         }
 
         public void TranslateTo(Messages.AcceptedChange message)

--- a/src/RoadRegistry.BackOffice/Core/RemoveRoadSegment.cs
+++ b/src/RoadRegistry.BackOffice/Core/RemoveRoadSegment.cs
@@ -30,7 +30,23 @@ namespace RoadRegistry.BackOffice.Core
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            return Problems.None;
+            var problems = Problems.None;
+
+            var segmentBefore = context.BeforeView.Segments[Id];
+
+            if (context.AfterView.View.Nodes.TryGetValue(segmentBefore.Start, out var beforeStartNode))
+            {
+                problems = problems.AddRange(
+                    beforeStartNode.VerifyTypeMatchesConnectedSegmentCount(context.AfterView.View, context.Translator));
+            }
+
+            if (context.AfterView.View.Nodes.TryGetValue(segmentBefore.End, out var beforeEndNode))
+            {
+                problems = problems.AddRange(
+                    beforeEndNode.VerifyTypeMatchesConnectedSegmentCount(context.AfterView.View, context.Translator));
+            }
+
+            return problems;
         }
 
         public void TranslateTo(Messages.AcceptedChange message)

--- a/src/RoadRegistry.BackOffice/Core/RoadNode.cs
+++ b/src/RoadRegistry.BackOffice/Core/RoadNode.cs
@@ -120,13 +120,13 @@ namespace RoadRegistry.BackOffice.Core
             }
             else if (Segments.Count == 1 && Type != RoadNodeType.EndNode)
             {
-                problems = problems.Add(RoadNodeTypeMismatch.New(translator.TranslateToTemporaryOrId(Id), Segments.Count, Type, new []{RoadNodeType.EndNode}));
+                problems = problems.Add(RoadNodeTypeMismatch.New(translator.TranslateToTemporaryOrId(Id), Segments.Select(translator.TranslateToTemporaryOrId).ToArray(), Type, new []{RoadNodeType.EndNode}));
             }
             else if (Segments.Count == 2)
             {
                 if (!Type.IsAnyOf(RoadNodeType.FakeNode, RoadNodeType.TurningLoopNode))
                 {
-                    problems = problems.Add(RoadNodeTypeMismatch.New(translator.TranslateToTemporaryOrId(Id), Segments.Count, Type, new []{RoadNodeType.FakeNode, RoadNodeType.TurningLoopNode}));
+                    problems = problems.Add(RoadNodeTypeMismatch.New(translator.TranslateToTemporaryOrId(Id), Segments.Select(translator.TranslateToTemporaryOrId).ToArray(), Type, new []{RoadNodeType.FakeNode, RoadNodeType.TurningLoopNode}));
                 }
                 else if (Type == RoadNodeType.FakeNode)
                 {
@@ -146,7 +146,7 @@ namespace RoadRegistry.BackOffice.Core
             }
             else if (Segments.Count > 2 && !Type.IsAnyOf(RoadNodeType.RealNode, RoadNodeType.MiniRoundabout))
             {
-                problems = problems.Add(RoadNodeTypeMismatch.New(translator.TranslateToTemporaryOrId(Id), Segments.Count, Type, new []{RoadNodeType.RealNode, RoadNodeType.MiniRoundabout}));
+                problems = problems.Add(RoadNodeTypeMismatch.New(translator.TranslateToTemporaryOrId(Id), Segments.Select(translator.TranslateToTemporaryOrId).ToArray(), Type, new []{RoadNodeType.RealNode, RoadNodeType.MiniRoundabout}));
             }
 
             return problems;

--- a/src/RoadRegistry.BackOffice/Core/RoadNodeTypeMismatch.cs
+++ b/src/RoadRegistry.BackOffice/Core/RoadNodeTypeMismatch.cs
@@ -11,10 +11,13 @@ namespace RoadRegistry.BackOffice.Core
         {
         }
 
-        public static RoadNodeTypeMismatch New(RoadNodeId node, int connectedSegmentCount,
+        public static RoadNodeTypeMismatch New(RoadNodeId node,
+            RoadSegmentId[] connectedSegments,
             RoadNodeType actualType,
             RoadNodeType[] expectedTypes)
         {
+            if (connectedSegments == null)
+                throw new ArgumentNullException(nameof(connectedSegments));
             if (expectedTypes == null)
                 throw new ArgumentNullException(nameof(expectedTypes));
             if (expectedTypes.Length == 0)
@@ -25,9 +28,10 @@ namespace RoadRegistry.BackOffice.Core
                 new ProblemParameter("RoadNodeId",
                     node.ToInt32().ToString()),
                 new ProblemParameter("ConnectedSegmentCount",
-                    connectedSegmentCount.ToString(CultureInfo.InvariantCulture)),
-                new ProblemParameter("Actual", actualType.ToString())
+                    connectedSegments.Length.ToString(CultureInfo.InvariantCulture)),
             };
+            parameters.AddRange(connectedSegments.Select(segment => new ProblemParameter("ConnectedSegmentId", segment.ToInt32().ToString())));
+            parameters.Add(new ProblemParameter("Actual", actualType.ToString()));
             parameters.AddRange(expectedTypes.Select(type => new ProblemParameter("Expected", type.ToString())));
             return new RoadNodeTypeMismatch(parameters);
         }

--- a/src/RoadRegistry.BackOffice/Core/RoadSegmentEndNodeRefersToRemovedNode.cs
+++ b/src/RoadRegistry.BackOffice/Core/RoadSegmentEndNodeRefersToRemovedNode.cs
@@ -1,0 +1,12 @@
+namespace RoadRegistry.BackOffice.Core
+{
+    public class RoadSegmentEndNodeRefersToRemovedNode : Error
+    {
+        public RoadSegmentEndNodeRefersToRemovedNode(RoadSegmentId segment, RoadNodeId node) 
+            : base(nameof(RoadSegmentEndNodeRefersToRemovedNode),
+                new ProblemParameter("SegmentId", segment.ToInt32().ToString()),
+                new ProblemParameter("NodeId", node.ToInt32().ToString()))
+        {
+        }
+    }
+}

--- a/src/RoadRegistry.BackOffice/Core/RoadSegmentStartNodeRefersToRemovedNode.cs
+++ b/src/RoadRegistry.BackOffice/Core/RoadSegmentStartNodeRefersToRemovedNode.cs
@@ -1,0 +1,12 @@
+namespace RoadRegistry.BackOffice.Core
+{
+    public class RoadSegmentStartNodeRefersToRemovedNode : Error
+    {
+        public RoadSegmentStartNodeRefersToRemovedNode(RoadSegmentId segment, RoadNodeId node) 
+            : base(nameof(RoadSegmentStartNodeRefersToRemovedNode),
+                new ProblemParameter("SegmentId", segment.ToInt32().ToString()),
+                new ProblemParameter("NodeId", node.ToInt32().ToString()))
+        {
+        }
+    }
+}

--- a/src/RoadRegistry.Editor.Projections/DutchTranslations/ProblemWithChange.cs
+++ b/src/RoadRegistry.Editor.Projections/DutchTranslations/ProblemWithChange.cs
@@ -41,7 +41,16 @@ namespace RoadRegistry.Editor.Projections.DutchTranslations
                         translation = "De wegknoop is met geen enkel wegsegment verbonden.";
                         break;
                     case nameof(RoadNodeTypeMismatch):
-                        translation = $"Het opgegeven wegknoop type {RoadNodeType.Parse(problem.Parameters[2].Value).Translation.Name} komt niet overeen met een van de verwachte wegknoop types:{string.Join(',', problem.Parameters.Skip(3).Select(parameter => RoadNodeType.Parse(parameter.Value).Translation.Name))}. De wegknoop is verbonden met {problem.Parameters[1].Value} wegsegment(-en).";
+                        translation = $"Het opgegeven wegknoop type {RoadNodeType.Parse(problem.Parameters.Single(p => p.Name == "Actual").Value).Translation.Name} van knoop {problem.Parameters.Single(p => p.Name == "RoadNodeId").Value} komt niet overeen met een van de verwachte wegknoop types: {string.Join(',', problem.Parameters.Where(p => p.Name == "Expected").Select(parameter => RoadNodeType.Parse(parameter.Value).Translation.Name))}. De wegknoop is verbonden met {problem.Parameters[1].Value} wegsegment(-en)";
+                        if (problem.Parameters.Any(p => p.Name == "ConnectedSegmentId"))
+                        {
+                            translation += $": {string.Join(',', problem.Parameters.Where(p => p.Name == "ConnectedSegmentId").Select(parameter => parameter.Value))}.";
+                        }
+                        else
+                        {
+                            translation += ".";
+                        }
+
                         break;
                     case nameof(FakeRoadNodeConnectedSegmentsDoNotDiffer):
                         translation = $"De attributen van de verbonden wegsegmenten ({problem.Parameters[1].Value} en {problem.Parameters[2].Value}) verschillen onvoldoende voor deze schijnknoop.";
@@ -129,6 +138,12 @@ namespace RoadRegistry.Editor.Projections.DutchTranslations
                         break;
                     case nameof(UpperAndLowerRoadSegmentDoNotIntersect):
                         translation = "Het bovenste en onderste wegsegment kruisen elkaar niet.";
+                        break;
+                    case nameof(RoadSegmentStartNodeRefersToRemovedNode):
+                        translation = $"De begin knoop van wegsegment {problem.Parameters[0].Value} verwijst naar een verwijderde knoop {problem.Parameters[1].Value}.";
+                        break;
+                    case nameof(RoadSegmentEndNodeRefersToRemovedNode):
+                        translation = $"De eind knoop van wegsegment {problem.Parameters[0].Value} verwijst naar een verwijderde knoop {problem.Parameters[1].Value}.";
                         break;
                     default:
                         translation = $"'{problem.Reason}' has no translation. Please fix it.";

--- a/test/RoadRegistry.Tests/BackOffice/Scenarios/ModifyRoadNodeScenarios.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Scenarios/ModifyRoadNodeScenarios.cs
@@ -841,6 +841,11 @@ namespace RoadRegistry.BackOffice.Scenarios
                                         },
                                         new Messages.ProblemParameter
                                         {
+                                            Name = "ConnectedSegmentId",
+                                            Value = Segment1Added.Id.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
                                             Name = "Actual",
                                             Value = ModifyStartNode1.Type
                                         },
@@ -929,6 +934,11 @@ namespace RoadRegistry.BackOffice.Scenarios
                                         {
                                             Name = "ConnectedSegmentCount",
                                             Value = "1"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = Segment1Added.Id.ToString()
                                         },
                                         new Messages.ProblemParameter
                                         {
@@ -1081,6 +1091,16 @@ namespace RoadRegistry.BackOffice.Scenarios
                                         {
                                             Name = "ConnectedSegmentCount",
                                             Value = "2"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = Segment1Added.Id.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = Segment2Added.Id.ToString()
                                         },
                                         new Messages.ProblemParameter
                                         {
@@ -1566,6 +1586,16 @@ namespace RoadRegistry.BackOffice.Scenarios
                                         {
                                             Name = "ConnectedSegmentCount",
                                             Value = "2"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = Segment1Added.Id.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = Segment2Added.Id.ToString()
                                         },
                                         new Messages.ProblemParameter
                                         {

--- a/test/RoadRegistry.Tests/BackOffice/Scenarios/RoadNetworkScenarios.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Scenarios/RoadNetworkScenarios.cs
@@ -871,6 +871,50 @@ namespace RoadRegistry.BackOffice.Scenarios
                                         },
                                         new Messages.ProblemParameter
                                         {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddStartNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "EndNode"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment1,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddStartNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "1"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
                                             Name = "Actual",
                                             Value = AddStartNode1.Type
                                         },
@@ -945,6 +989,50 @@ namespace RoadRegistry.BackOffice.Scenarios
                                         {
                                             Name = "ConnectedSegmentCount",
                                             Value = "1"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddEndNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "EndNode"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment1,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddEndNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "1"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
                                         },
                                         new Messages.ProblemParameter
                                         {
@@ -1081,6 +1169,114 @@ namespace RoadRegistry.BackOffice.Scenarios
                                         {
                                             Name = "ConnectedSegmentCount",
                                             Value = "2"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddStartNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "FakeNode"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "TurningLoopNode"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment1,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddStartNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "2"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddStartNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "FakeNode"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "TurningLoopNode"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment2,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddStartNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "2"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
                                         },
                                         new Messages.ProblemParameter
                                         {
@@ -1290,12 +1486,62 @@ namespace RoadRegistry.BackOffice.Scenarios
                         new Messages.AcceptedChange
                         {
                             RoadSegmentAdded = Segment1Added,
-                            Problems = Array.Empty<Messages.Problem>()
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "FakeRoadNodeConnectedSegmentsDoNotDiffer",
+                                    Severity = ProblemSeverity.Warning,
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddStartNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "SegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "SegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        }
+                                    }
+                                }
+                            }
                         },
                         new Messages.AcceptedChange
                         {
                             RoadSegmentAdded = Segment2Added,
-                            Problems = Array.Empty<Messages.Problem>()
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "FakeRoadNodeConnectedSegmentsDoNotDiffer",
+                                    Severity = ProblemSeverity.Warning,
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddStartNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "SegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "SegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        }
+                                    }
+                                }
+                            }
                         }
                     },
                     When = InstantPattern.ExtendedIso.Format(Clock.GetCurrentInstant())
@@ -1607,6 +1853,114 @@ namespace RoadRegistry.BackOffice.Scenarios
                                         },
                                         new Messages.ProblemParameter
                                         {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddEndNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "FakeNode"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "TurningLoopNode"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment1,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddEndNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "2"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddEndNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "FakeNode"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "TurningLoopNode"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment2,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddEndNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "2"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
                                             Name = "Actual",
                                             Value = AddEndNode1.Type
                                         },
@@ -1655,8 +2009,11 @@ namespace RoadRegistry.BackOffice.Scenarios
             };
             AddStartNode1.Geometry = Core.GeometryTranslator.Translate(startPoint);
             AddEndNode1.Geometry = Core.GeometryTranslator.Translate(endPoint1);
+            AddEndNode1.Type = RoadNodeType.EndNode.ToString();
             AddEndNode2.Geometry = Core.GeometryTranslator.Translate(endPoint2);
+            AddEndNode2.Type = RoadNodeType.EndNode.ToString();
             AddEndNode3.Geometry = Core.GeometryTranslator.Translate(endPoint3);
+            AddEndNode3.Type = RoadNodeType.EndNode.ToString();
             AddSegment1.Lanes = new RequestedRoadSegmentLaneAttribute[0];
             Segment1Added.Lanes = new Messages.RoadSegmentLaneAttributes[0];
             AddSegment1.Widths = new RequestedRoadSegmentWidthAttribute[0];
@@ -1776,6 +2133,183 @@ namespace RoadRegistry.BackOffice.Scenarios
                                         {
                                             Name = "ConnectedSegmentCount",
                                             Value = "3"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment3.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddStartNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "RealNode"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "MiniRoundabout"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment1,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddStartNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "3"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment3.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddStartNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "RealNode"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "MiniRoundabout"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment2,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddStartNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "3"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment3.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddStartNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "RealNode"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "MiniRoundabout"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment3,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddStartNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "3"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment3.TemporaryId.ToString()
                                         },
                                         new Messages.ProblemParameter
                                         {
@@ -1948,6 +2482,183 @@ namespace RoadRegistry.BackOffice.Scenarios
                                         {
                                             Name = "ConnectedSegmentCount",
                                             Value = "3"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment3.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddEndNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "RealNode"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "MiniRoundabout"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment1,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddEndNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "3"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment3.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddEndNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "RealNode"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "MiniRoundabout"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment2,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddEndNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "3"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment3.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Actual",
+                                            Value = AddEndNode1.Type
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "RealNode"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "Expected",
+                                            Value = "MiniRoundabout"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new Messages.RejectedChange
+                        {
+                            AddRoadSegment = AddSegment3,
+                            Problems = new[]
+                            {
+                                new Messages.Problem
+                                {
+                                    Reason = "RoadNodeTypeMismatch",
+                                    Parameters = new []
+                                    {
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "RoadNodeId",
+                                            Value = AddEndNode1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentCount",
+                                            Value = "3"
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment1.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment2.TemporaryId.ToString()
+                                        },
+                                        new Messages.ProblemParameter
+                                        {
+                                            Name = "ConnectedSegmentId",
+                                            Value = AddSegment3.TemporaryId.ToString()
                                         },
                                         new Messages.ProblemParameter
                                         {
@@ -2560,6 +3271,8 @@ namespace RoadRegistry.BackOffice.Scenarios
         [Fact]
         public Task when_adding_a_segment_with_a_geometry_that_has_been_taken()
         {
+            StartNode1Added.Type = RoadNodeType.FakeNode.ToString();
+            EndNode1Added.Type = RoadNodeType.FakeNode.ToString();
             AddSegment2.StartNodeId = StartNode1Added.Id;
             AddSegment2.EndNodeId = EndNode1Added.Id;
             AddSegment2.Geometry = Segment1Added.Geometry;
@@ -3147,6 +3860,9 @@ namespace RoadRegistry.BackOffice.Scenarios
         public Task when_adding_a_segment_whose_start_point_does_not_match_its_existing_start_node_geometry()
         {
             AddSegment2.StartNodeId = StartNode1Added.Id;
+            StartNode1Added.Type = RoadNodeType.FakeNode.ToString();
+            EndNode1Added.Type = RoadNodeType.EndNode.ToString();
+            AddEndNode2.Type = RoadNodeType.EndNode.ToString();
 
             return Run(scenario => scenario
                 .Given(Organizations.StreamNameFactory(ChangedByOrganization),
@@ -3270,6 +3986,9 @@ namespace RoadRegistry.BackOffice.Scenarios
         public Task when_adding_a_segment_whose_end_point_does_not_match_its_existing_end_node_geometry()
         {
             AddSegment2.EndNodeId = EndNode1Added.Id;
+            StartNode1Added.Type = RoadNodeType.EndNode.ToString();
+            EndNode1Added.Type = RoadNodeType.FakeNode.ToString();
+            AddStartNode2.Type = RoadNodeType.EndNode.ToString();
 
             return Run(scenario => scenario
                 .Given(Organizations.StreamNameFactory(ChangedByOrganization),


### PR DESCRIPTION
This PR adds more road node type checking after changes have been applied, notably when adding / modifying / removing a road node and adding / modifying / removing a road segment. In each case, the affected road nodes and their type will be checked against the road segments they are currently connected with.

In addition it fixes an issue where switching start and end nodes of a road segment (either combined with another node or simply by exchanging them) would cause the road network view to no longer correctly track the connected segments.