### PR TITLE
fix: provide authless health check location

### DIFF
--- a/src/RoadRegistry.BackOffice.UI/default.conf
+++ b/src/RoadRegistry.BackOffice.UI/default.conf
@@ -13,6 +13,12 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    location /health {
+        access_log off;
+        return 200 'healthy';
+        add_header Content-Type text/plain;
+    }
+
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html


### PR DESCRIPTION
Health check fails because of basic auth on nginx in docker container.
This fix provides an endpoint without basic auth so the health check can
pass.