### PR TITLE
feat: ability to download extract

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -365,6 +365,7 @@ services:
       MINIO_SECRET_KEY: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
       BLOBCLIENTTYPE: S3BlobClient
       S3BLOBCLIENTOPTIONS__BUCKETS__UPLOADS: road-registry-uploads
+      S3BLOBCLIENTOPTIONS__BUCKETS__EXTRACTDOWNLOADS: road-registry-extract-downloads
       CONNECTIONSTRINGS__SNAPSHOTS: Data Source=tcp:mssql,1433;Initial Catalog=RoadRegistry;Integrated Security=False;User ID=sa;Password=E@syP@ssw0rd;
       CONNECTIONSTRINGS__EVENTS: Data Source=tcp:mssql,1433;Initial Catalog=RoadRegistry;Integrated Security=False;User ID=sa;Password=E@syP@ssw0rd;
       CONNECTIONSTRINGS__EDITORPROJECTIONS: Data Source=tcp:mssql,1433;Initial Catalog=RoadRegistry;Integrated Security=False;User ID=sa;Password=E@syP@ssw0rd;

--- a/src/RoadRegistry.BackOffice.Api/Configuration/ExtractDownloadsOptions.cs
+++ b/src/RoadRegistry.BackOffice.Api/Configuration/ExtractDownloadsOptions.cs
@@ -1,0 +1,8 @@
+namespace RoadRegistry.BackOffice.Api.Configuration
+{
+    public class ExtractDownloadsOptions
+    {
+        public int DefaultRetryAfter { get; set; } = 60;
+        public int RetryAfterAverageWindowInDays { get; set; } = 30;
+    }
+}

--- a/src/RoadRegistry.BackOffice.Api/ExtractDownloadsBlobClient.cs
+++ b/src/RoadRegistry.BackOffice.Api/ExtractDownloadsBlobClient.cs
@@ -1,0 +1,39 @@
+namespace RoadRegistry.BackOffice.Api
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Be.Vlaanderen.Basisregisters.BlobStore;
+
+    public class ExtractDownloadsBlobClient : IBlobClient
+    {
+        private readonly IBlobClient _client;
+
+        public ExtractDownloadsBlobClient(IBlobClient client)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public Task<BlobObject> GetBlobAsync(BlobName name, CancellationToken cancellationToken = default)
+        {
+            return _client.GetBlobAsync(name, cancellationToken);
+        }
+
+        public Task<bool> BlobExistsAsync(BlobName name, CancellationToken cancellationToken = default)
+        {
+            return _client.BlobExistsAsync(name, cancellationToken);
+        }
+
+        public Task CreateBlobAsync(BlobName name, Metadata metadata, ContentType contentType, Stream content,
+            CancellationToken cancellationToken = default)
+        {
+            return _client.CreateBlobAsync(name, metadata, contentType, content, cancellationToken);
+        }
+
+        public Task DeleteBlobAsync(BlobName name, CancellationToken cancellationToken = default)
+        {
+            return _client.DeleteBlobAsync(name, cancellationToken);
+        }
+    }
+}

--- a/src/RoadRegistry.BackOffice.Api/Extracts/ExtractDownloadQueryExtensions.cs
+++ b/src/RoadRegistry.BackOffice.Api/Extracts/ExtractDownloadQueryExtensions.cs
@@ -1,0 +1,40 @@
+namespace RoadRegistry.BackOffice.Api.Extracts
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Editor.Schema.Extracts;
+    using Microsoft.EntityFrameworkCore;
+    using NodaTime;
+
+    internal static class ExtractDownloadQueryExtensions
+    {
+        public static async Task<int> TookAverageAssembleDuration(this DbSet<ExtractDownloadRecord> source, Instant since, int defaultValue)
+        {
+            // NOTE: This query takes into account all extract downloads that took an hour or less to assemble
+            // and computes the median (or the 0.5 or 50th percentile) of that dataset, that is, 50% of the assembly durations
+            // took at most the median value (or less). We also limit the data set to anything more recent or equal to the moment
+            // identified by the since parameter. Next we compute the average of the resulting set.
+            if (await source.AnyAsync())
+            {
+                return Convert.ToInt32(await source.FromSqlRaw(@"
+SELECT DownloadId, ExternalRequestId, RequestId, ArchiveId, RequestedOn, Available, AvailableOn
+FROM RoadRegistryEditor.ExtractDownload
+WHERE Available = 1
+AND RequestedOn >= {0}
+AND (AvailableOn - RequestedOn) <= (
+    SELECT TOP 1
+        PERCENTILE_DISC(0.5)
+        WITHIN GROUP (ORDER BY (AvailableOn - RequestedOn))
+        OVER ()
+    FROM RoadRegistryEditor.ExtractDownload
+    WHERE Available = 1
+    AND (AvailableOn - RequestedOn) <= 3600)
+    AND RequestedOn >= {1}", since.ToUnixTimeSeconds(), since.ToUnixTimeSeconds())
+                    .AverageAsync(download => download.AvailableOn - download.RequestedOn));
+            }
+
+            return defaultValue;
+        }
+    }
+}

--- a/src/RoadRegistry.BackOffice.Api/Extracts/ExtractsController.cs
+++ b/src/RoadRegistry.BackOffice.Api/Extracts/ExtractsController.cs
@@ -1,14 +1,23 @@
 namespace RoadRegistry.BackOffice.Api.Extracts
 {
     using System;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net;
     using System.Threading.Tasks;
     using BackOffice.Framework;
     using Be.Vlaanderen.Basisregisters.Api;
-    using Be.Vlaanderen.Basisregisters.Api.Exceptions;
+    using Be.Vlaanderen.Basisregisters.BlobStore;
+    using Editor.Schema;
     using FluentValidation;
+    using FluentValidation.Results;
+    using Framework;
     using Messages;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Net.Http.Headers;
     using NetTopologySuite.IO;
+    using NodaTime;
 
     [ApiVersion("1.0")]
     [AdvertiseApiVersions("1.0")]
@@ -17,15 +26,21 @@ namespace RoadRegistry.BackOffice.Api.Extracts
     public class ExtractsController : ControllerBase
     {
         private readonly CommandHandlerDispatcher _dispatcher;
+        private readonly ExtractDownloadsBlobClient _client;
         private readonly WKTReader _reader;
         private readonly IValidator<DownloadExtractRequestBody> _downloadExtractRequestBodyValidator;
+        private readonly IClock _clock;
 
         public ExtractsController(
+            IClock clock,
             CommandHandlerDispatcher dispatcher,
+            ExtractDownloadsBlobClient client,
             WKTReader reader,
             IValidator<DownloadExtractRequestBody> downloadExtractRequestBodyValidator)
         {
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
             _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+            _client = client ?? throw new ArgumentNullException(nameof(client));
             _reader = reader ?? throw new ArgumentNullException(nameof(reader));
             _downloadExtractRequestBodyValidator = downloadExtractRequestBodyValidator ?? throw new ArgumentNullException(nameof(downloadExtractRequestBodyValidator));
         }
@@ -49,9 +64,67 @@ namespace RoadRegistry.BackOffice.Api.Extracts
         }
 
         [HttpGet("download/{downloadid}")]
-        public Task<IActionResult> GetDownload([FromRoute]string downloadid)
+        public async Task<IActionResult> GetDownload([FromServices]EditorContext context, [FromRoute]string downloadid)
         {
-            return Task.FromResult<IActionResult>(null);
+            if (Guid.TryParseExact(downloadid, "N", out var parsed))
+            {
+                var record = await context.ExtractDownloads.FindAsync(new object[] { parsed }, HttpContext.RequestAborted);
+                if (record == null || !record.Available)
+                {
+                    // NOT FOUND (with retry after)
+                    // NOTE: using this approach the system calculates
+                    // var bufferSeconds = 5;
+                    // var thirtyDays = Duration.FromDays(30);
+                    // var thirtyDaysAgo = _clock.GetCurrentInstant().Minus(thirtyDays).ToUnixTimeTicks();
+                    // var average = await context.ExtractDownloads
+                    //     .Where(download => download.Available && download.AvailableOn > thirtyDaysAgo)
+                    //     .AverageAsync(download => download.RequestedOn - download.AvailableOn,
+                    //         HttpContext.RequestAborted);
+                    // var retryAfterSeconds =
+                    //     (
+                    //         Convert.ToInt32(Math.Round(Duration.FromTicks(average).TotalSeconds, 0, MidpointRounding.ToEven))
+                    //         +
+                    //         bufferSeconds
+                    //     )
+                    //     .ToString(CultureInfo.InvariantCulture);
+                    Response.Headers.Add("Retry-After", "5");
+                    return NotFound();
+                }
+
+                // FOUND
+
+                var blobName = new BlobName(record.ArchiveId);
+
+                if(!await _client.BlobExistsAsync(blobName, HttpContext.RequestAborted))
+                {
+                    // NOTE: This condition can only occur if the blob no longer exists in the bucket
+                    return StatusCode((int)HttpStatusCode.Gone);
+                }
+
+                var blob = await _client.GetBlobAsync(blobName, HttpContext.RequestAborted);
+
+                var filename = downloadid + ".zip";
+
+                return new FileCallbackResult(
+                    new MediaTypeHeaderValue("application/zip"),
+                    async (stream, actionContext) =>
+                    {
+                        using (var blobStream = await blob.OpenAsync(actionContext.HttpContext.RequestAborted))
+                        {
+                            await blobStream.CopyToAsync(stream, actionContext.HttpContext.RequestAborted);
+                        }
+                    })
+                {
+                    FileDownloadName = filename
+                };
+            }
+
+            // results in BAD REQUEST
+            throw new ValidationException(new[]
+            {
+                new ValidationFailure("downloadid",
+                    "The 'downloadid' querystring parameter is not a global unique identifier without dashes.")
+            });
         }
     }
 }

--- a/src/RoadRegistry.BackOffice.Api/Program.cs
+++ b/src/RoadRegistry.BackOffice.Api/Program.cs
@@ -174,11 +174,14 @@ namespace RoadRegistry.BackOffice.Api
 
                     var zipArchiveWriterOptions = new ZipArchiveWriterOptions();
                     hostContext.Configuration.GetSection(nameof(ZipArchiveWriterOptions)).Bind(zipArchiveWriterOptions);
+                    var extractDownloadsOptions = new ExtractDownloadsOptions();
+                    hostContext.Configuration.GetSection(nameof(ExtractDownloadsOptions)).Bind(extractDownloadsOptions);
 
                     builder
                         .AddSingleton<Extracts.DownloadExtractRequestBodyValidator>()
                         .AddSingleton<ProblemDetailsHelper>()
                         .AddSingleton<ZipArchiveWriterOptions>(zipArchiveWriterOptions)
+                        .AddSingleton<ExtractDownloadsOptions>(extractDownloadsOptions)
                         .AddSingleton<IStreamStore>(sp =>
                             new MsSqlStreamStoreV3(
                                 new MsSqlStreamStoreV3Settings(

--- a/src/RoadRegistry.BackOffice.Api/Program.cs
+++ b/src/RoadRegistry.BackOffice.Api/Program.cs
@@ -140,12 +140,17 @@ namespace RoadRegistry.BackOffice.Api
                                 );
                             }
 
-                            builder.AddSingleton<IBlobClient>(sp =>
-                                new S3BlobClient(
-                                    sp.GetRequiredService<AmazonS3Client>(),
-                                    s3Options.Buckets[WellknownBuckets.UploadsBucket]
-                                )
-                            );
+                            builder
+                                .AddSingleton(sp =>
+                                    new UploadsBlobClient(new S3BlobClient(
+                                        sp.GetRequiredService<AmazonS3Client>(),
+                                        s3Options.Buckets[WellknownBuckets.UploadsBucket]
+                                    )))
+                                .AddSingleton(sp =>
+                                    new ExtractDownloadsBlobClient(new S3BlobClient(
+                                        sp.GetRequiredService<AmazonS3Client>(),
+                                        s3Options.Buckets[WellknownBuckets.ExtractDownloadsBucket]
+                                    )));
 
                             break;
 
@@ -153,11 +158,14 @@ namespace RoadRegistry.BackOffice.Api
                             var fileOptions = new FileBlobClientOptions();
                             hostContext.Configuration.GetSection(nameof(FileBlobClientOptions)).Bind(fileOptions);
 
-                            builder.AddSingleton<IBlobClient>(sp =>
-                                new FileBlobClient(
-                                    new DirectoryInfo(fileOptions.Directory)
+                            builder
+                                .AddSingleton<IBlobClient>(sp =>
+                                    new FileBlobClient(
+                                        new DirectoryInfo(fileOptions.Directory)
+                                    )
                                 )
-                            );
+                                .AddSingleton<UploadsBlobClient>()
+                                .AddSingleton<ExtractDownloadsBlobClient>();
                             break;
 
                         default:
@@ -200,7 +208,7 @@ namespace RoadRegistry.BackOffice.Api
                             new CommandHandlerModule[]
                             {
                                 new RoadNetworkChangesArchiveCommandModule(
-                                    sp.GetService<IBlobClient>(),
+                                    sp.GetService<UploadsBlobClient>(),
                                     sp.GetService<IStreamStore>(),
                                     sp.GetService<IRoadNetworkSnapshotReader>(),
                                     new ZipArchiveValidator(Encoding.GetEncoding(1252)),

--- a/src/RoadRegistry.BackOffice.Api/Startup.cs
+++ b/src/RoadRegistry.BackOffice.Api/Startup.cs
@@ -46,7 +46,8 @@ namespace RoadRegistry.BackOffice.Api
                             .GetSection("Cors")
                             .GetChildren()
                             .Select(c => c.Value)
-                            .ToArray()
+                            .ToArray(),
+                        ExposedHeaders = new [] { "Retry-After" }
                     },
                     Swagger =
                     {

--- a/src/RoadRegistry.BackOffice.Api/Uploads/UploadController.cs
+++ b/src/RoadRegistry.BackOffice.Api/Uploads/UploadController.cs
@@ -26,9 +26,9 @@ namespace RoadRegistry.BackOffice.Api.Uploads
                 ContentType.Parse("application/x-zip-compressed")
             };
         private readonly CommandHandlerDispatcher _dispatcher;
-        private readonly IBlobClient _client;
+        private readonly UploadsBlobClient _client;
 
-        public UploadController(CommandHandlerDispatcher dispatcher, IBlobClient client)
+        public UploadController(CommandHandlerDispatcher dispatcher, UploadsBlobClient client)
         {
             _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
             _client = client ?? throw new ArgumentNullException(nameof(client));

--- a/src/RoadRegistry.BackOffice.Api/UploadsBlobClient.cs
+++ b/src/RoadRegistry.BackOffice.Api/UploadsBlobClient.cs
@@ -1,0 +1,39 @@
+namespace RoadRegistry.BackOffice.Api
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Be.Vlaanderen.Basisregisters.BlobStore;
+
+    public class UploadsBlobClient : IBlobClient
+    {
+        private readonly IBlobClient _client;
+
+        public UploadsBlobClient(IBlobClient client)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public Task<BlobObject> GetBlobAsync(BlobName name, CancellationToken cancellationToken = default)
+        {
+            return _client.GetBlobAsync(name, cancellationToken);
+        }
+
+        public Task<bool> BlobExistsAsync(BlobName name, CancellationToken cancellationToken = default)
+        {
+            return _client.BlobExistsAsync(name, cancellationToken);
+        }
+
+        public Task CreateBlobAsync(BlobName name, Metadata metadata, ContentType contentType, Stream content,
+            CancellationToken cancellationToken = default)
+        {
+            return _client.CreateBlobAsync(name, metadata, contentType, content, cancellationToken);
+        }
+
+        public Task DeleteBlobAsync(BlobName name, CancellationToken cancellationToken = default)
+        {
+            return _client.DeleteBlobAsync(name, cancellationToken);
+        }
+    }
+}

--- a/src/RoadRegistry.BackOffice.Api/WellknownBuckets.cs
+++ b/src/RoadRegistry.BackOffice.Api/WellknownBuckets.cs
@@ -3,5 +3,6 @@ namespace RoadRegistry.BackOffice.Api
     internal static class WellknownBuckets
     {
         public const string UploadsBucket = "Uploads";
+        public const string ExtractDownloadsBucket = "ExtractDownloads";
     }
 }

--- a/src/RoadRegistry.BackOffice.Api/appsettings.development.json
+++ b/src/RoadRegistry.BackOffice.Api/appsettings.development.json
@@ -24,7 +24,8 @@
   "S3BlobClientOptions":
   {
     "Buckets":{
-      "Uploads": "road-registry-uploads"
+      "Uploads": "road-registry-uploads",
+      "ExtractDownloads": "road-registry-extract-downloads"
     }
   },
   "Minio_Server"    : "http://minio:9000",

--- a/src/RoadRegistry.BackOffice.Api/appsettings.development.json
+++ b/src/RoadRegistry.BackOffice.Api/appsettings.development.json
@@ -11,7 +11,7 @@
       {
         "Name": "Seq",
         "Args": {
-          "serverUrl": "http://seq:5341"
+          "serverUrl": "http://localhost:5341"
         }
       }
     ]

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/ContourQueryExtensions.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/ContourQueryExtensions.cs
@@ -11,6 +11,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using NetTopologySuite.Geometries;
     using NetTopologySuite.IO;
 
+    // NOTE: If you change the properties of any of the entities used below, you will need to update these queries too!
     public static class ContourQueryExtensions
     {
         private static SqlParameter ToSqlParameter(this MultiPolygon contour)

--- a/src/RoadRegistry.Editor.ProjectionHost/Program.cs
+++ b/src/RoadRegistry.Editor.ProjectionHost/Program.cs
@@ -198,7 +198,8 @@
                             new RoadSegmentNumberedRoadAttributeRecordProjection(sp.GetRequiredService<RecyclableMemoryStreamManager>(), WindowsAnsiEncoding),
                             new RoadSegmentRecordProjection(sp.GetRequiredService<RecyclableMemoryStreamManager>(), WindowsAnsiEncoding),
                             new RoadSegmentSurfaceAttributeRecordProjection(sp.GetRequiredService<RecyclableMemoryStreamManager>(), WindowsAnsiEncoding),
-                            new RoadSegmentWidthAttributeRecordProjection(sp.GetRequiredService<RecyclableMemoryStreamManager>(), WindowsAnsiEncoding)
+                            new RoadSegmentWidthAttributeRecordProjection(sp.GetRequiredService<RecyclableMemoryStreamManager>(), WindowsAnsiEncoding),
+                            new ExtractDownloadRecordProjection()
                         })
                         .AddSingleton(sp =>
                             Resolve

--- a/src/RoadRegistry.Editor.Projections/ExtractDownloadRecordProjection.cs
+++ b/src/RoadRegistry.Editor.Projections/ExtractDownloadRecordProjection.cs
@@ -1,0 +1,43 @@
+namespace RoadRegistry.Editor.Projections
+{
+    using System.Linq;
+    using BackOffice.Messages;
+    using Be.Vlaanderen.Basisregisters.ProjectionHandling.Connector;
+    using Be.Vlaanderen.Basisregisters.ProjectionHandling.SqlStreamStore;
+    using Microsoft.EntityFrameworkCore;
+    using NodaTime;
+    using NodaTime.Text;
+    using Schema;
+    using Schema.Extracts;
+
+    public class ExtractDownloadRecordProjection : ConnectedProjection<EditorContext>
+    {
+        public ExtractDownloadRecordProjection()
+        {
+            When<Envelope<RoadNetworkExtractGotRequested>>(async (context, envelope, ct) =>
+            {
+                var record = new ExtractDownloadRecord
+                {
+                    ExternalRequestId = envelope.Message.ExternalRequestId,
+                    RequestId = envelope.Message.RequestId,
+                    DownloadId = envelope.Message.DownloadId,
+                    ArchiveId = null,
+                    Available = false,
+                    AvailableOn = 0L,
+                    RequestedOn = InstantPattern.ExtendedIso.Parse(envelope.Message.When).Value.ToUnixTimeTicks()
+                };
+                await context.ExtractDownloads.AddAsync(record, ct);
+            });
+
+            When<Envelope<RoadNetworkExtractDownloadBecameAvailable>>(async (context, envelope, ct) =>
+            {
+                var record =
+                    context.ExtractDownloads.Local.SingleOrDefault(download => download.DownloadId == envelope.Message.DownloadId)
+                    ?? await context.ExtractDownloads.SingleAsync(download => download.DownloadId == envelope.Message.DownloadId, ct);
+                record.ArchiveId = envelope.Message.ArchiveId;
+                record.Available = true;
+                record.AvailableOn = InstantPattern.ExtendedIso.Parse(envelope.Message.When).Value.ToUnixTimeTicks();
+            });
+        }
+    }
+}

--- a/src/RoadRegistry.Editor.Projections/ExtractDownloadRecordProjection.cs
+++ b/src/RoadRegistry.Editor.Projections/ExtractDownloadRecordProjection.cs
@@ -24,7 +24,7 @@ namespace RoadRegistry.Editor.Projections
                     ArchiveId = null,
                     Available = false,
                     AvailableOn = 0L,
-                    RequestedOn = InstantPattern.ExtendedIso.Parse(envelope.Message.When).Value.ToUnixTimeTicks()
+                    RequestedOn = InstantPattern.ExtendedIso.Parse(envelope.Message.When).Value.ToUnixTimeSeconds()
                 };
                 await context.ExtractDownloads.AddAsync(record, ct);
             });
@@ -36,7 +36,7 @@ namespace RoadRegistry.Editor.Projections
                     ?? await context.ExtractDownloads.SingleAsync(download => download.DownloadId == envelope.Message.DownloadId, ct);
                 record.ArchiveId = envelope.Message.ArchiveId;
                 record.Available = true;
-                record.AvailableOn = InstantPattern.ExtendedIso.Parse(envelope.Message.When).Value.ToUnixTimeTicks();
+                record.AvailableOn = InstantPattern.ExtendedIso.Parse(envelope.Message.When).Value.ToUnixTimeSeconds();
             });
         }
     }

--- a/src/RoadRegistry.Editor.Schema/EditorContext.cs
+++ b/src/RoadRegistry.Editor.Schema/EditorContext.cs
@@ -4,6 +4,7 @@ namespace RoadRegistry.Editor.Schema
     using System.Threading;
     using System.Threading.Tasks;
     using Be.Vlaanderen.Basisregisters.ProjectionHandling.Runner;
+    using Extracts;
     using GradeSeparatedJunctions;
     using Microsoft.EntityFrameworkCore;
     using Organizations;
@@ -33,6 +34,7 @@ namespace RoadRegistry.Editor.Schema
         public DbSet<RoadNetworkChange> RoadNetworkChanges { get; set; }
         public DbSet<RoadNetworkChangeRequestBasedOnArchive> RoadNetworkChangeRequestsBasedOnArchive { get; set; }
         public DbSet<MunicipalityGeometry> MunicipalityGeometries { get; set; }
+        public DbSet<ExtractDownloadRecord> ExtractDownloads { get; set; }
 
         public async ValueTask<RoadNetworkInfo> GetRoadNetworkInfo(CancellationToken token)
         {

--- a/src/RoadRegistry.Editor.Schema/Extracts/ExtractDownloadConfiguration.cs
+++ b/src/RoadRegistry.Editor.Schema/Extracts/ExtractDownloadConfiguration.cs
@@ -1,0 +1,25 @@
+namespace RoadRegistry.Editor.Schema.Extracts
+{
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+    public class ExtractDownloadConfiguration : IEntityTypeConfiguration<ExtractDownloadRecord>
+    {
+        private const string TableName = "ExtractDownload";
+
+        public void Configure(EntityTypeBuilder<ExtractDownloadRecord> b)
+        {
+            b.ToTable(TableName, WellknownSchemas.EditorSchema)
+                .HasKey(p => p.DownloadId)
+                .IsClustered(false);
+
+            b.Property(p => p.DownloadId).ValueGeneratedNever().IsRequired();
+            b.Property(p => p.ArchiveId).IsRequired(false);
+            b.Property(p => p.RequestId).IsRequired();
+            b.Property(p => p.ExternalRequestId).IsRequired();
+            b.Property(p => p.RequestedOn).IsRequired();
+            b.Property(p => p.Available).IsRequired();
+            b.Property(p => p.AvailableOn).IsRequired();
+        }
+    }
+}

--- a/src/RoadRegistry.Editor.Schema/Extracts/ExtractDownloadRecord.cs
+++ b/src/RoadRegistry.Editor.Schema/Extracts/ExtractDownloadRecord.cs
@@ -1,0 +1,15 @@
+namespace RoadRegistry.Editor.Schema.Extracts
+{
+    using System;
+
+    public class ExtractDownloadRecord
+    {
+        public Guid DownloadId { get; set; }
+        public string ExternalRequestId { get; set; }
+        public string RequestId { get; set; }
+        public string ArchiveId { get; set; }
+        public long RequestedOn { get; set; }
+        public bool Available { get; set; }
+        public long AvailableOn { get; set; }
+    }
+}

--- a/src/RoadRegistry.Editor.Schema/Migrations/20210715130035_AddExtractDownloadRecord.Designer.cs
+++ b/src/RoadRegistry.Editor.Schema/Migrations/20210715130035_AddExtractDownloadRecord.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using RoadRegistry.Editor.Schema;
@@ -10,9 +11,10 @@ using RoadRegistry.Editor.Schema;
 namespace RoadRegistry.Editor.Schema.Migrations
 {
     [DbContext(typeof(EditorContext))]
-    partial class EditorContextModelSnapshot : ModelSnapshot
+    [Migration("20210715130035_AddExtractDownloadRecord")]
+    partial class AddExtractDownloadRecord
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/RoadRegistry.Editor.Schema/Migrations/20210715130035_AddExtractDownloadRecord.cs
+++ b/src/RoadRegistry.Editor.Schema/Migrations/20210715130035_AddExtractDownloadRecord.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace RoadRegistry.Editor.Schema.Migrations
+{
+    public partial class AddExtractDownloadRecord : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExtractDownload",
+                schema: "RoadRegistryEditor",
+                columns: table => new
+                {
+                    DownloadId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ExternalRequestId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    RequestId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ArchiveId = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    RequestedOn = table.Column<long>(type: "bigint", nullable: false),
+                    Available = table.Column<bool>(type: "bit", nullable: false),
+                    AvailableOn = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExtractDownload", x => x.DownloadId)
+                        .Annotation("SqlServer:Clustered", false);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExtractDownload",
+                schema: "RoadRegistryEditor");
+        }
+    }
+}

--- a/src/RoadRegistry.Editor.Schema/Organizations/OrganizationConfiguration.cs
+++ b/src/RoadRegistry.Editor.Schema/Organizations/OrganizationConfiguration.cs
@@ -11,7 +11,7 @@ namespace RoadRegistry.Editor.Schema.Organizations
         {
             b.ToTable(TableName, WellknownSchemas.EditorSchema)
                 .HasIndex(p => p.Id)
-                .IsClustered();
+                .IsClustered(false);
 
             b.Property(p => p.Id).ValueGeneratedOnAdd().IsRequired();
             b.Property(p => p.Code).IsRequired();

--- a/test/RoadRegistry.Tests/BackOffice/Api/ExtractControllerTests.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Api/ExtractControllerTests.cs
@@ -4,6 +4,7 @@ namespace RoadRegistry.BackOffice.Api
     using AutoFixture;
     using BackOffice.Extracts;
     using BackOffice.Framework;
+    using Be.Vlaanderen.Basisregisters.BlobStore.Memory;
     using Be.Vlaanderen.Basisregisters.Shaperon.Geometries;
     using Extracts;
     using FluentValidation;
@@ -48,7 +49,7 @@ namespace RoadRegistry.BackOffice.Api
             var validator =
                 new DownloadExtractRequestBodyValidator(wktReader,
                     new NullLogger<DownloadExtractRequestBodyValidator>());
-            var controller = new ExtractsController(Dispatch.Using(_resolver), wktReader, validator)
+            var controller = new ExtractsController(SystemClock.Instance, Dispatch.Using(_resolver), new ExtractDownloadsBlobClient(new MemoryBlobClient()), wktReader, validator)
             {
                 ControllerContext = new ControllerContext {HttpContext = new DefaultHttpContext()}
             };
@@ -74,7 +75,7 @@ namespace RoadRegistry.BackOffice.Api
             var validator =
                 new DownloadExtractRequestBodyValidator(wktReader,
                     new NullLogger<DownloadExtractRequestBodyValidator>());
-            var controller = new ExtractsController(Dispatch.Using(_resolver), wktReader, validator)
+            var controller = new ExtractsController(SystemClock.Instance,Dispatch.Using(_resolver), new ExtractDownloadsBlobClient(new MemoryBlobClient()), wktReader, validator)
             {
                 ControllerContext = new ControllerContext {HttpContext = new DefaultHttpContext()}
             };
@@ -100,7 +101,7 @@ namespace RoadRegistry.BackOffice.Api
             var validator =
                 new DownloadExtractRequestBodyValidator(wktReader,
                     new NullLogger<DownloadExtractRequestBodyValidator>());
-            var controller = new ExtractsController(Dispatch.Using(_resolver), wktReader, validator)
+            var controller = new ExtractsController(SystemClock.Instance,Dispatch.Using(_resolver), new ExtractDownloadsBlobClient(new MemoryBlobClient()), wktReader, validator)
             {
                 ControllerContext = new ControllerContext {HttpContext = new DefaultHttpContext()}
             };
@@ -130,7 +131,7 @@ namespace RoadRegistry.BackOffice.Api
             var validator =
                 new DownloadExtractRequestBodyValidator(wktReader,
                     new NullLogger<DownloadExtractRequestBodyValidator>());
-            var controller = new ExtractsController(Dispatch.Using(_resolver), wktReader, validator)
+            var controller = new ExtractsController(SystemClock.Instance,Dispatch.Using(_resolver), new ExtractDownloadsBlobClient(new MemoryBlobClient()), wktReader, validator)
             {
                 ControllerContext = new ControllerContext {HttpContext = new DefaultHttpContext()}
             };

--- a/test/RoadRegistry.Tests/BackOffice/Api/UploadControllerTests.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Api/UploadControllerTests.cs
@@ -24,7 +24,7 @@ namespace RoadRegistry.BackOffice.Api
         [Fact]
         public async Task When_uploading_a_file_that_is_not_a_zip()
         {
-            var client = new MemoryBlobClient();
+            var client = new UploadsBlobClient(new MemoryBlobClient());
             var store = new InMemoryStreamStore();
             var validator = new ZipArchiveValidator(Encoding.UTF8);
             var resolver = Resolve.WhenEqualToMessage(
@@ -59,7 +59,7 @@ namespace RoadRegistry.BackOffice.Api
         [InlineData("application/x-zip-compressed")]
         public async Task When_uploading_a_file_that_is_a_zip(string contentType)
         {
-            var client = new MemoryBlobClient();
+            var client = new UploadsBlobClient(new MemoryBlobClient());
             var store = new InMemoryStreamStore();
             var validator = new ZipArchiveValidator(Encoding.UTF8);
             var resolver = Resolve.WhenEqualToMessage(
@@ -125,7 +125,7 @@ namespace RoadRegistry.BackOffice.Api
         [Fact]
         public async Task When_uploading_an_externally_created_file_that_is_a_zip()
         {
-            var client = new MemoryBlobClient();
+            var client = new UploadsBlobClient(new MemoryBlobClient());
             var store = new InMemoryStreamStore();
             var validator = new ZipArchiveValidator(Encoding.UTF8);
             var resolver = Resolve.WhenEqualToMessage(

--- a/test/RoadRegistry.Tests/Editor/Projections/ExtractDownloadRecordProjectionTests.cs
+++ b/test/RoadRegistry.Tests/Editor/Projections/ExtractDownloadRecordProjectionTests.cs
@@ -1,0 +1,143 @@
+namespace RoadRegistry.Editor.Projections
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AutoFixture;
+    using BackOffice;
+    using BackOffice.Messages;
+    using Be.Vlaanderen.Basisregisters.Shaperon;
+    using Framework.Projections;
+    using NodaTime;
+    using NodaTime.Text;
+    using Schema.Extracts;
+    using Xunit;
+
+    public class ExtractDownloadRecordProjectionTests
+    {
+        private readonly Fixture _fixture;
+
+        public ExtractDownloadRecordProjectionTests()
+        {
+            _fixture = new Fixture();
+            _fixture.CustomizeArchiveId();
+            _fixture.CustomizeExternalExtractRequestId();
+            _fixture.Customize<RoadNetworkExtractGotRequested>(
+                customization =>
+                    customization
+                        .FromFactory(generator =>
+                            {
+                                var externalRequestId = _fixture.Create<ExternalExtractRequestId>();
+                                return new RoadNetworkExtractGotRequested
+                                {
+                                    DownloadId = _fixture.Create<Guid>(),
+                                    ExternalRequestId = externalRequestId,
+                                    RequestId = ExtractRequestId.FromExternalRequestId(externalRequestId),
+                                    Contour = new RoadNetworkExtractGeometry
+                                    {
+                                        SpatialReferenceSystemIdentifier =
+                                            SpatialReferenceSystemIdentifier.BelgeLambert1972.ToInt32(),
+                                        MultiPolygon = new BackOffice.Messages.Polygon[0]
+                                    },
+                                    When = InstantPattern.ExtendedIso.Format(SystemClock.Instance.GetCurrentInstant())
+                                };
+                            }
+                        )
+                        .OmitAutoProperties()
+            );
+            _fixture.Customize<RoadNetworkExtractDownloadBecameAvailable>(
+                customization =>
+                    customization
+                        .FromFactory(generator =>
+                            {
+                                var externalRequestId = _fixture.Create<ExternalExtractRequestId>();
+                                return new RoadNetworkExtractDownloadBecameAvailable
+                                {
+                                    DownloadId = _fixture.Create<Guid>(),
+                                    ExternalRequestId = externalRequestId,
+                                    RequestId = ExtractRequestId.FromExternalRequestId(externalRequestId),
+                                    ArchiveId = _fixture.Create<ArchiveId>(),
+                                    When = InstantPattern.ExtendedIso.Format(SystemClock.Instance.GetCurrentInstant())
+                                };
+                            }
+                        )
+                        .OmitAutoProperties()
+            );
+        }
+
+        [Fact]
+        public Task When_extract_got_requested()
+        {
+            var data = _fixture
+                .CreateMany<RoadNetworkExtractGotRequested>()
+                .Select(requested =>
+                {
+                    var expected = new ExtractDownloadRecord
+                    {
+                        DownloadId = requested.DownloadId,
+                        RequestId = requested.RequestId,
+                        ExternalRequestId = requested.ExternalRequestId,
+                        ArchiveId = null,
+                        Available = false,
+                        AvailableOn = 0L,
+                        RequestedOn = InstantPattern.ExtendedIso.Parse(requested.When).Value.ToUnixTimeTicks()
+                    };
+
+                    return new
+                    {
+                        @event = requested,
+                        expected
+                    };
+                }).ToList();
+
+            return new ExtractDownloadRecordProjection()
+                .Scenario()
+                .Given(data.Select(d => d.@event))
+                .Expect(data.Select(d => d.expected));
+        }
+
+        [Fact]
+        public Task When_extract_download_became_available()
+        {
+            var data = _fixture
+                .CreateMany<RoadNetworkExtractDownloadBecameAvailable>()
+                .Select(available =>
+                {
+                    var expected = new ExtractDownloadRecord
+                    {
+                        DownloadId = available.DownloadId,
+                        RequestId = available.RequestId,
+                        ExternalRequestId = available.ExternalRequestId,
+                        ArchiveId = available.ArchiveId,
+                        Available = true,
+                        AvailableOn = InstantPattern.ExtendedIso.Parse(available.When).Value.ToUnixTimeTicks(),
+                        RequestedOn = InstantPattern.ExtendedIso.Parse(available.When).Value.ToUnixTimeTicks()
+                    };
+
+                    return new
+                    {
+                        given = new RoadNetworkExtractGotRequested
+                        {
+                            ExternalRequestId = available.ExternalRequestId,
+                            RequestId = available.RequestId,
+                            DownloadId = available.DownloadId,
+                            Contour = new RoadNetworkExtractGeometry
+                            {
+                                SpatialReferenceSystemIdentifier =
+                                    SpatialReferenceSystemIdentifier.BelgeLambert1972.ToInt32(),
+                                MultiPolygon = new BackOffice.Messages.Polygon[0]
+                            },
+                            When = InstantPattern.ExtendedIso.Format(InstantPattern.ExtendedIso.Parse(available.When).Value)
+                        },
+                        @event = available,
+                        expected
+                    };
+                }).ToList();
+
+            return new ExtractDownloadRecordProjection()
+                .Scenario()
+                .Given(data.SelectMany(d => new object[] { d.given, d.@event }))
+                .Expect(data.Select(d => d.expected));
+        }
+    }
+}

--- a/test/RoadRegistry.Tests/Editor/Projections/ExtractDownloadRecordProjectionTests.cs
+++ b/test/RoadRegistry.Tests/Editor/Projections/ExtractDownloadRecordProjectionTests.cs
@@ -80,7 +80,7 @@ namespace RoadRegistry.Editor.Projections
                         ArchiveId = null,
                         Available = false,
                         AvailableOn = 0L,
-                        RequestedOn = InstantPattern.ExtendedIso.Parse(requested.When).Value.ToUnixTimeTicks()
+                        RequestedOn = InstantPattern.ExtendedIso.Parse(requested.When).Value.ToUnixTimeSeconds()
                     };
 
                     return new
@@ -110,8 +110,8 @@ namespace RoadRegistry.Editor.Projections
                         ExternalRequestId = available.ExternalRequestId,
                         ArchiveId = available.ArchiveId,
                         Available = true,
-                        AvailableOn = InstantPattern.ExtendedIso.Parse(available.When).Value.ToUnixTimeTicks(),
-                        RequestedOn = InstantPattern.ExtendedIso.Parse(available.When).Value.ToUnixTimeTicks()
+                        AvailableOn = InstantPattern.ExtendedIso.Parse(available.When).Value.ToUnixTimeSeconds(),
+                        RequestedOn = InstantPattern.ExtendedIso.Parse(available.When).Value.ToUnixTimeSeconds()
                     };
 
                     return new

--- a/test/RoadRegistry.Tests/Framework/Projections/EditorContextScenarioExtensions.cs
+++ b/test/RoadRegistry.Tests/Framework/Projections/EditorContextScenarioExtensions.cs
@@ -281,6 +281,8 @@ namespace RoadRegistry.Framework.Projections
             records.AddRange(await context.RoadNetworkInfo.ToArrayAsync());
             records.AddRange(await context.RoadNetworkChanges.ToArrayAsync());
             records.AddRange(await context.MunicipalityGeometries.ToArrayAsync());
+            records.AddRange(await context.ExtractDownloads.ToArrayAsync());
+
             return records.ToArray();
         }
 


### PR DESCRIPTION
This PR introduces the ability to download an extract based on the download id. If the download is not yet available at the time or was never found or no extracts ever got requested, we apologize with a `404 Not Found` and a `Retry-After` header that tries to indicate when would be a good time to try to `GET` the download again. If the associated archive could not be found in the underlying blob storage (S3), then we return `410 Gone` - it's expected for this to never happen, yet it beats a null reference exception.