### PR TITLE
feat: prefix with e and transaction zone support

### DIFF
--- a/src/RoadRegistry.BackOffice.Api/Extracts/DownloadExtractRequestBodyValidator.cs
+++ b/src/RoadRegistry.BackOffice.Api/Extracts/DownloadExtractRequestBodyValidator.cs
@@ -17,10 +17,11 @@ namespace RoadRegistry.BackOffice.Api.Extracts
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             RuleFor(c => c.RequestId)
-                .NotEmpty();
+                .NotEmpty().WithMessage("'RequestId' must not be empty, null or missing");
             RuleFor(c => c.Contour)
-                .NotEmpty()
+                .NotEmpty().WithMessage("'Contour' must not be empty, null or missing")
                 .Must(BeMultiPolygonGeometryAsWellKnownText)
+                .WithMessage("'Contour' must be a valid multipolygon represented as well-known text")
                 .When(c => !string.IsNullOrEmpty(c.Contour), ApplyConditionTo.CurrentValidator);
         }
 

--- a/src/RoadRegistry.BackOffice.Api/Extracts/ExtractsController.cs
+++ b/src/RoadRegistry.BackOffice.Api/Extracts/ExtractsController.cs
@@ -116,7 +116,7 @@ namespace RoadRegistry.BackOffice.Api.Extracts
             throw new ValidationException(new[]
             {
                 new ValidationFailure("downloadid",
-                    "The 'downloadid' querystring parameter is not a global unique identifier without dashes.")
+                    "'DownloadId' querystring parameter is not a global unique identifier without dashes.")
             });
         }
     }

--- a/src/RoadRegistry.BackOffice.ExtractHost/RoadNetworkExtractArchiveAssembler.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/RoadNetworkExtractArchiveAssembler.cs
@@ -28,15 +28,15 @@ namespace RoadRegistry.BackOffice.ExtractHost
             _writer = writer ?? throw new ArgumentNullException(nameof(writer));
         }
 
-        public async Task<MemoryStream> AssembleWithin(MultiPolygon contour, CancellationToken cancellationToken)
+        public async Task<MemoryStream> AssembleArchive(RoadNetworkExtractAssemblyRequest request, CancellationToken cancellationToken)
         {
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
 
             var stream = _manager.GetStream();
             using (var context = _contextFactory())
             using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, true, Encoding.UTF8))
             {
-                await _writer.WriteAsync(archive, contour, context, cancellationToken);
+                await _writer.WriteAsync(archive, request, context, cancellationToken);
             }
 
             return stream;

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/CompositeZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/CompositeZipArchiveWriter.cs
@@ -4,6 +4,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using System.IO.Compression;
     using System.Threading;
     using System.Threading.Tasks;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using NetTopologySuite.Geometries;
 
@@ -16,15 +17,16 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _writers = writers ?? throw new ArgumentNullException(nameof(writers));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, TContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request, TContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             foreach (var writer in _writers)
             {
-                await writer.WriteAsync(archive, contour, context, cancellationToken);
+                await writer.WriteAsync(archive, request, context, cancellationToken);
             }
         }
     }

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/DbaseFileArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/DbaseFileArchiveWriter.cs
@@ -8,6 +8,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using System.Threading;
     using System.Threading.Tasks;
     using Be.Vlaanderen.Basisregisters.Shaperon;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using NetTopologySuite.Geometries;
 
@@ -26,10 +27,11 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, TContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request, TContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var dbfEntry = archive.CreateEntry(_filename);

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/GradeSeparatedJunctionArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/GradeSeparatedJunctionArchiveWriter.cs
@@ -10,9 +10,9 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Be.Vlaanderen.Basisregisters.Shaperon;
     using Editor.Schema;
     using Editor.Schema.GradeSeparatedJunctions;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.IO;
-    using NetTopologySuite.Geometries;
 
     public class GradeSeparatedJunctionArchiveWriter : IZipArchiveWriter<EditorContext>
     {
@@ -25,15 +25,17 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var junctions =
                 await context.GradeSeparatedJunctions
-                    .InsideContour(contour)
+                    .InsideContour(request.Contour)
                     .ToListAsync(cancellationToken);
             var dbfEntry = archive.CreateEntry("eRltOgkruising.dbf");
             var dbfHeader = new DbaseFileHeader(

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/GradeSeparatedJunctionArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/GradeSeparatedJunctionArchiveWriter.cs
@@ -35,7 +35,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
                 await context.GradeSeparatedJunctions
                     .InsideContour(contour)
                     .ToListAsync(cancellationToken);
-            var dbfEntry = archive.CreateEntry("RltOgkruising.dbf");
+            var dbfEntry = archive.CreateEntry("eRltOgkruising.dbf");
             var dbfHeader = new DbaseFileHeader(
                 DateTime.Now,
                 DbaseCodePage.Western_European_ANSI,

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/IZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/IZipArchiveWriter.cs
@@ -3,11 +3,12 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using System.IO.Compression;
     using System.Threading;
     using System.Threading.Tasks;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
-    using NetTopologySuite.Geometries;
 
     public interface IZipArchiveWriter<in TContext> where TContext : DbContext
     {
-        Task WriteAsync(ZipArchive archive, MultiPolygon contour, TContext context, CancellationToken cancellationToken);
+        Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request, TContext context,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/OrganizationsToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/OrganizationsToZipArchiveWriter.cs
@@ -32,7 +32,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             if (contour == null) throw new ArgumentNullException(nameof(contour));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            var dbfEntry = archive.CreateEntry("LstOrg.dbf");
+            var dbfEntry = archive.CreateEntry("eLstOrg.dbf");
             var dbfHeader = new DbaseFileHeader(
                 DateTime.Now,
                 DbaseCodePage.Western_European_ANSI,

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/OrganizationsToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/OrganizationsToZipArchiveWriter.cs
@@ -11,6 +11,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Core;
     using Editor.Schema;
     using Editor.Schema.Organizations;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.IO;
     using NetTopologySuite.Geometries;
@@ -26,10 +27,12 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var dbfEntry = archive.CreateEntry("eLstOrg.dbf");

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/ProjectionFormatFileZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/ProjectionFormatFileZipArchiveWriter.cs
@@ -6,6 +6,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using NetTopologySuite.Geometries;
 
@@ -19,10 +20,11 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _filename = filename ?? throw new ArgumentNullException(nameof(filename));
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, TContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request, TContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
             var prjEntry = archive.CreateEntry(_filename);
             using (var prjEntryStream = prjEntry.Open())

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/ReadCommittedZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/ReadCommittedZipArchiveWriter.cs
@@ -5,6 +5,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using System.IO.Compression;
     using System.Threading;
     using System.Threading.Tasks;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using NetTopologySuite.Geometries;
 
@@ -17,15 +18,16 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _writer = writer ?? throw new ArgumentNullException(nameof(writer));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, TContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request, TContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             using (await context.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken))
             {
-                await _writer.WriteAsync(archive, contour, context, cancellationToken);
+                await _writer.WriteAsync(archive, request, context, cancellationToken);
             }
         }
     }

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadNetworkExtractToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadNetworkExtractToZipArchiveWriter.cs
@@ -41,18 +41,18 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
                         new GradeSeparatedJunctionArchiveWriter(manager, encoding)
                     )
                 ),
-                new DbaseFileArchiveWriter<EditorContext>("WegknoopLktType.dbf", RoadNodeTypeDbaseRecord.Schema, Lists.AllRoadNodeTypeDbaseRecords, encoding),
-                new DbaseFileArchiveWriter<EditorContext>("WegverhardLktType.dbf", SurfaceTypeDbaseRecord.Schema, Lists.AllSurfaceTypeDbaseRecords, encoding),
-                new DbaseFileArchiveWriter<EditorContext>("GenumwegLktRichting.dbf", NumberedRoadSegmentDirectionDbaseRecord.Schema, Lists.AllNumberedRoadSegmentDirectionDbaseRecords, encoding),
-                new DbaseFileArchiveWriter<EditorContext>("WegsegmentLktWegcat.dbf", RoadSegmentCategoryDbaseRecord.Schema, Lists.AllRoadSegmentCategoryDbaseRecords, encoding),
-                new DbaseFileArchiveWriter<EditorContext>("WegsegmentLktTgbep.dbf", RoadSegmentAccessRestrictionDbaseRecord.Schema, Lists.AllRoadSegmentAccessRestrictionDbaseRecords, encoding),
-                new DbaseFileArchiveWriter<EditorContext>("WegsegmentLktMethode.dbf", RoadSegmentGeometryDrawMethodDbaseRecord.Schema, Lists.AllRoadSegmentGeometryDrawMethodDbaseRecords, encoding),
-                new DbaseFileArchiveWriter<EditorContext>("WegsegmentLktMorf.dbf", RoadSegmentMorphologyDbaseRecord.Schema, Lists.AllRoadSegmentMorphologyDbaseRecords, encoding),
-                new DbaseFileArchiveWriter<EditorContext>("WegsegmentLktStatus.dbf", RoadSegmentStatusDbaseRecord.Schema, Lists.AllRoadSegmentStatusDbaseRecords, encoding),
-                new DbaseFileArchiveWriter<EditorContext>("OgkruisingLktType.dbf", GradeSeparatedJunctionTypeDbaseRecord.Schema, Lists.AllGradeSeparatedJunctionTypeDbaseRecords, encoding),
-                new DbaseFileArchiveWriter<EditorContext>("RijstrokenLktRichting.dbf", LaneDirectionDbaseRecord.Schema, Lists.AllLaneDirectionDbaseRecords, encoding),
-                new ProjectionFormatFileZipArchiveWriter<EditorContext>("Wegsegment.prj", encoding),
-                new ProjectionFormatFileZipArchiveWriter<EditorContext>("Wegknoop.prj", encoding)
+                new DbaseFileArchiveWriter<EditorContext>("eWegknoopLktType.dbf", RoadNodeTypeDbaseRecord.Schema, Lists.AllRoadNodeTypeDbaseRecords, encoding),
+                new DbaseFileArchiveWriter<EditorContext>("eWegverhardLktType.dbf", SurfaceTypeDbaseRecord.Schema, Lists.AllSurfaceTypeDbaseRecords, encoding),
+                new DbaseFileArchiveWriter<EditorContext>("eGenumwegLktRichting.dbf", NumberedRoadSegmentDirectionDbaseRecord.Schema, Lists.AllNumberedRoadSegmentDirectionDbaseRecords, encoding),
+                new DbaseFileArchiveWriter<EditorContext>("eWegsegmentLktWegcat.dbf", RoadSegmentCategoryDbaseRecord.Schema, Lists.AllRoadSegmentCategoryDbaseRecords, encoding),
+                new DbaseFileArchiveWriter<EditorContext>("eWegsegmentLktTgbep.dbf", RoadSegmentAccessRestrictionDbaseRecord.Schema, Lists.AllRoadSegmentAccessRestrictionDbaseRecords, encoding),
+                new DbaseFileArchiveWriter<EditorContext>("eWegsegmentLktMethode.dbf", RoadSegmentGeometryDrawMethodDbaseRecord.Schema, Lists.AllRoadSegmentGeometryDrawMethodDbaseRecords, encoding),
+                new DbaseFileArchiveWriter<EditorContext>("eWegsegmentLktMorf.dbf", RoadSegmentMorphologyDbaseRecord.Schema, Lists.AllRoadSegmentMorphologyDbaseRecords, encoding),
+                new DbaseFileArchiveWriter<EditorContext>("eWegsegmentLktStatus.dbf", RoadSegmentStatusDbaseRecord.Schema, Lists.AllRoadSegmentStatusDbaseRecords, encoding),
+                new DbaseFileArchiveWriter<EditorContext>("eOgkruisingLktType.dbf", GradeSeparatedJunctionTypeDbaseRecord.Schema, Lists.AllGradeSeparatedJunctionTypeDbaseRecords, encoding),
+                new DbaseFileArchiveWriter<EditorContext>("eRijstrokenLktRichting.dbf", LaneDirectionDbaseRecord.Schema, Lists.AllLaneDirectionDbaseRecords, encoding),
+                new ProjectionFormatFileZipArchiveWriter<EditorContext>("eWegsegment.prj", encoding),
+                new ProjectionFormatFileZipArchiveWriter<EditorContext>("eWegknoop.prj", encoding)
             );
         }
 

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadNetworkExtractToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadNetworkExtractToZipArchiveWriter.cs
@@ -8,6 +8,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Configuration;
     using Editor.Schema;
     using Editor.Schema.Lists;
+    using Extracts;
     using Microsoft.IO;
     using NetTopologySuite.Geometries;
 
@@ -29,6 +30,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _writer = new CompositeZipArchiveWriter<EditorContext>(
                 new ReadCommittedZipArchiveWriter<EditorContext>(
                     new CompositeZipArchiveWriter<EditorContext>(
+                        new TransactionZoneToZipArchiveWriter(encoding),
                         new OrganizationsToZipArchiveWriter(manager, encoding),
                         new RoadNodesToZipArchiveWriter(manager, encoding),
                         new RoadSegmentsToZipArchiveWriter(zipArchiveWriterOptions, streetNameCache, manager, encoding),
@@ -52,13 +54,15 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
                 new DbaseFileArchiveWriter<EditorContext>("eOgkruisingLktType.dbf", GradeSeparatedJunctionTypeDbaseRecord.Schema, Lists.AllGradeSeparatedJunctionTypeDbaseRecords, encoding),
                 new DbaseFileArchiveWriter<EditorContext>("eRijstrokenLktRichting.dbf", LaneDirectionDbaseRecord.Schema, Lists.AllLaneDirectionDbaseRecords, encoding),
                 new ProjectionFormatFileZipArchiveWriter<EditorContext>("eWegsegment.prj", encoding),
-                new ProjectionFormatFileZipArchiveWriter<EditorContext>("eWegknoop.prj", encoding)
+                new ProjectionFormatFileZipArchiveWriter<EditorContext>("eWegknoop.prj", encoding),
+                new ProjectionFormatFileZipArchiveWriter<EditorContext>("eTransactiezones.prj", encoding)
             );
         }
 
-        public Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request, EditorContext context,
+            CancellationToken cancellationToken)
         {
-            return _writer.WriteAsync(archive, contour, context, cancellationToken);
+            return _writer.WriteAsync(archive, request, context, cancellationToken);
         }
     }
 }

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadNodesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadNodesToZipArchiveWriter.cs
@@ -10,10 +10,9 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Be.Vlaanderen.Basisregisters.Shaperon;
     using Editor.Schema;
     using Editor.Schema.RoadNodes;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.IO;
-    using NetTopologySuite.Geometries;
-    using NetTopologySuite.Planargraph;
 
     public class RoadNodesToZipArchiveWriter : IZipArchiveWriter<EditorContext>
     {
@@ -26,14 +25,16 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var nodes =
-                await context.RoadNodes.InsideContour(contour).ToListAsync(cancellationToken);
+                await context.RoadNodes.InsideContour(request.Contour).ToListAsync(cancellationToken);
 
             var dbfEntry = archive.CreateEntry("eWegknoop.dbf");
             var dbfHeader = new DbaseFileHeader(

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadNodesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadNodesToZipArchiveWriter.cs
@@ -35,7 +35,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             var nodes =
                 await context.RoadNodes.InsideContour(contour).ToListAsync(cancellationToken);
 
-            var dbfEntry = archive.CreateEntry("Wegknoop.dbf");
+            var dbfEntry = archive.CreateEntry("eWegknoop.dbf");
             var dbfHeader = new DbaseFileHeader(
                 DateTime.Now,
                 DbaseCodePage.Western_European_ANSI,
@@ -63,7 +63,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
                     BoundingBox3D.Empty,
                     (box, record) => box.ExpandWith(record.BoundingBox.ToBoundingBox3D()));
 
-            var shpEntry = archive.CreateEntry("Wegknoop.shp");
+            var shpEntry = archive.CreateEntry("eWegknoop.shp");
             var shpHeader = new ShapeFileHeader(
                 new WordLength(
                     nodes.Aggregate(0, (length, record) => length + record.ShapeRecordContentLength)),
@@ -89,7 +89,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
                 await shpEntryStream.FlushAsync(cancellationToken);
             }
 
-            var shxEntry = archive.CreateEntry("Wegknoop.shx");
+            var shxEntry = archive.CreateEntry("eWegknoop.shx");
             var shxHeader = shpHeader.ForIndex(new ShapeRecordCount(nodes.Count));
             await using (var shxEntryStream = shxEntry.Open())
             using (var shxWriter =

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentEuropeanRoadAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentEuropeanRoadAttributesToZipArchiveWriter.cs
@@ -10,9 +10,9 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Be.Vlaanderen.Basisregisters.Shaperon;
     using Editor.Schema;
     using Editor.Schema.RoadSegments;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.IO;
-    using NetTopologySuite.Geometries;
 
     public class RoadSegmentEuropeanRoadAttributesToZipArchiveWriter : IZipArchiveWriter<EditorContext>
     {
@@ -26,14 +26,16 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var attributes = await context.RoadSegmentEuropeanRoadAttributes
-                .InsideContour(contour)
+                .InsideContour(request.Contour)
                 .ToListAsync(cancellationToken);
 
             var dbfEntry = archive.CreateEntry("eAttEuropweg.dbf");

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentEuropeanRoadAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentEuropeanRoadAttributesToZipArchiveWriter.cs
@@ -36,7 +36,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
                 .InsideContour(contour)
                 .ToListAsync(cancellationToken);
 
-            var dbfEntry = archive.CreateEntry("AttEuropweg.dbf");
+            var dbfEntry = archive.CreateEntry("eAttEuropweg.dbf");
             var dbfHeader = new DbaseFileHeader(
                 DateTime.Now,
                 DbaseCodePage.Western_European_ANSI,

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentLaneAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentLaneAttributesToZipArchiveWriter.cs
@@ -34,7 +34,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             var attributes = await context.RoadSegmentLaneAttributes
                 .InsideContour(contour)
                 .ToListAsync(cancellationToken);
-            var dbfEntry = archive.CreateEntry("AttRijstroken.dbf");
+            var dbfEntry = archive.CreateEntry("eAttRijstroken.dbf");
             var dbfHeader = new DbaseFileHeader(
                 DateTime.Now,
                 DbaseCodePage.Western_European_ANSI,

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentLaneAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentLaneAttributesToZipArchiveWriter.cs
@@ -10,9 +10,9 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Be.Vlaanderen.Basisregisters.Shaperon;
     using Editor.Schema;
     using Editor.Schema.RoadSegments;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.IO;
-    using NetTopologySuite.Geometries;
 
     public class RoadSegmentLaneAttributesToZipArchiveWriter : IZipArchiveWriter<EditorContext>
     {
@@ -25,14 +25,16 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var attributes = await context.RoadSegmentLaneAttributes
-                .InsideContour(contour)
+                .InsideContour(request.Contour)
                 .ToListAsync(cancellationToken);
             var dbfEntry = archive.CreateEntry("eAttRijstroken.dbf");
             var dbfHeader = new DbaseFileHeader(

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentNationalRoadAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentNationalRoadAttributesToZipArchiveWriter.cs
@@ -10,9 +10,9 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Be.Vlaanderen.Basisregisters.Shaperon;
     using Editor.Schema;
     using Editor.Schema.RoadSegments;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.IO;
-    using NetTopologySuite.Geometries;
 
     public class RoadSegmentNationalRoadAttributesToZipArchiveWriter : IZipArchiveWriter<EditorContext>
     {
@@ -26,14 +26,16 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var attributes = await context.RoadSegmentNationalRoadAttributes
-                .InsideContour(contour)
+                .InsideContour(request.Contour)
                 .ToListAsync(cancellationToken);
 
             var dbfEntry = archive.CreateEntry("eAttNationweg.dbf");

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentNationalRoadAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentNationalRoadAttributesToZipArchiveWriter.cs
@@ -36,7 +36,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
                 .InsideContour(contour)
                 .ToListAsync(cancellationToken);
 
-            var dbfEntry = archive.CreateEntry("AttNationweg.dbf");
+            var dbfEntry = archive.CreateEntry("eAttNationweg.dbf");
             var dbfHeader = new DbaseFileHeader(
                 DateTime.Now,
                 DbaseCodePage.Western_European_ANSI,

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentNumberedRoadAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentNumberedRoadAttributesToZipArchiveWriter.cs
@@ -35,7 +35,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             var attributes = await context.RoadSegmentNumberedRoadAttributes
                 .InsideContour(contour)
                 .ToListAsync(cancellationToken);
-            var dbfEntry = archive.CreateEntry("AttGenumweg.dbf");
+            var dbfEntry = archive.CreateEntry("eAttGenumweg.dbf");
             var dbfHeader = new DbaseFileHeader(
                 DateTime.Now,
                 DbaseCodePage.Western_European_ANSI,

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentNumberedRoadAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentNumberedRoadAttributesToZipArchiveWriter.cs
@@ -10,9 +10,9 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Be.Vlaanderen.Basisregisters.Shaperon;
     using Editor.Schema;
     using Editor.Schema.RoadSegments;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.IO;
-    using NetTopologySuite.Geometries;
 
     public class RoadSegmentNumberedRoadAttributesToZipArchiveWriter : IZipArchiveWriter<EditorContext>
     {
@@ -26,14 +26,16 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var attributes = await context.RoadSegmentNumberedRoadAttributes
-                .InsideContour(contour)
+                .InsideContour(request.Contour)
                 .ToListAsync(cancellationToken);
             var dbfEntry = archive.CreateEntry("eAttGenumweg.dbf");
             var dbfHeader = new DbaseFileHeader(

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentSurfaceAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentSurfaceAttributesToZipArchiveWriter.cs
@@ -34,7 +34,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             var attributes = await context.RoadSegmentSurfaceAttributes
                 .InsideContour(contour)
                 .ToListAsync(cancellationToken);
-            var dbfEntry = archive.CreateEntry("AttWegverharding.dbf");
+            var dbfEntry = archive.CreateEntry("eAttWegverharding.dbf");
             var dbfHeader = new DbaseFileHeader(
                 DateTime.Now,
                 DbaseCodePage.Western_European_ANSI,

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentSurfaceAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentSurfaceAttributesToZipArchiveWriter.cs
@@ -10,9 +10,9 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Be.Vlaanderen.Basisregisters.Shaperon;
     using Editor.Schema;
     using Editor.Schema.RoadSegments;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.IO;
-    using NetTopologySuite.Geometries;
 
     public class RoadSegmentSurfaceAttributesToZipArchiveWriter : IZipArchiveWriter<EditorContext>
     {
@@ -25,14 +25,16 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var attributes = await context.RoadSegmentSurfaceAttributes
-                .InsideContour(contour)
+                .InsideContour(request.Contour)
                 .ToListAsync(cancellationToken);
             var dbfEntry = archive.CreateEntry("eAttWegverharding.dbf");
             var dbfHeader = new DbaseFileHeader(

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentWidthAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentWidthAttributesToZipArchiveWriter.cs
@@ -10,9 +10,9 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Be.Vlaanderen.Basisregisters.Shaperon;
     using Editor.Schema;
     using Editor.Schema.RoadSegments;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.IO;
-    using NetTopologySuite.Geometries;
 
     public class RoadSegmentWidthAttributesToZipArchiveWriter : IZipArchiveWriter<EditorContext>
     {
@@ -25,14 +25,16 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var attributes = await context.RoadSegmentWidthAttributes
-                .InsideContour(contour)
+                .InsideContour(request.Contour)
                 .ToListAsync(cancellationToken);
             var dbfEntry = archive.CreateEntry("eAttWegbreedte.dbf");
             var dbfHeader = new DbaseFileHeader(

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentWidthAttributesToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentWidthAttributesToZipArchiveWriter.cs
@@ -34,7 +34,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             var attributes = await context.RoadSegmentWidthAttributes
                 .InsideContour(contour)
                 .ToListAsync(cancellationToken);
-            var dbfEntry = archive.CreateEntry("AttWegbreedte.dbf");
+            var dbfEntry = archive.CreateEntry("eAttWegbreedte.dbf");
             var dbfHeader = new DbaseFileHeader(
                 DateTime.Now,
                 DbaseCodePage.Western_European_ANSI,

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentsToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentsToZipArchiveWriter.cs
@@ -11,9 +11,9 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     using Configuration;
     using Editor.Schema;
     using Editor.Schema.RoadSegments;
+    using Extracts;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.IO;
-    using NetTopologySuite.Geometries;
 
     public class RoadSegmentsToZipArchiveWriter : IZipArchiveWriter<EditorContext>
     {
@@ -34,14 +34,16 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        public async Task WriteAsync(ZipArchive archive, MultiPolygon contour, EditorContext context, CancellationToken cancellationToken)
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
         {
             if (archive == null) throw new ArgumentNullException(nameof(archive));
-            if (contour == null) throw new ArgumentNullException(nameof(contour));
+            if (request == null) throw new ArgumentNullException(nameof(request));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var segments = await context.RoadSegments
-                .InsideContour(contour)
+                .InsideContour(request.Contour)
                 .ToListAsync(cancellationToken);
             var dbfEntry = archive.CreateEntry("eWegsegment.dbf");
             var dbfHeader = new DbaseFileHeader(

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentsToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/RoadSegmentsToZipArchiveWriter.cs
@@ -43,7 +43,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
             var segments = await context.RoadSegments
                 .InsideContour(contour)
                 .ToListAsync(cancellationToken);
-            var dbfEntry = archive.CreateEntry("Wegsegment.dbf");
+            var dbfEntry = archive.CreateEntry("eWegsegment.dbf");
             var dbfHeader = new DbaseFileHeader(
                 DateTime.Now,
                 DbaseCodePage.Western_European_ANSI,
@@ -95,7 +95,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
                 BoundingBox3D.Empty,
                 (box, record) => box.ExpandWith(record.BoundingBox.ToBoundingBox3D()));
 
-            var shpEntry = archive.CreateEntry("Wegsegment.shp");
+            var shpEntry = archive.CreateEntry("eWegsegment.shp");
             var shpHeader = new ShapeFileHeader(
                 new WordLength(
                     segments.Aggregate(0, (length, record) => length + record.ShapeRecordContentLength)),
@@ -121,7 +121,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
                 await shpEntryStream.FlushAsync(cancellationToken);
             }
 
-            var shxEntry = archive.CreateEntry("Wegsegment.shx");
+            var shxEntry = archive.CreateEntry("eWegsegment.shx");
             var shxHeader = shpHeader.ForIndex(new ShapeRecordCount(segments.Count));
             await using (var shxEntryStream = shxEntry.Open())
             using (var shxWriter =

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/TransactionZoneToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/TransactionZoneToZipArchiveWriter.cs
@@ -1,0 +1,99 @@
+namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
+{
+    using System;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Be.Vlaanderen.Basisregisters.Shaperon;
+    using Be.Vlaanderen.Basisregisters.Shaperon.Geometries;
+    using Editor.Schema;
+    using Editor.Schema.Extracts;
+    using Editor.Schema.RoadNodes;
+    using Extracts;
+    using Microsoft.IO;
+
+    public class TransactionZoneToZipArchiveWriter : IZipArchiveWriter<EditorContext>
+    {
+        private readonly Encoding _encoding;
+
+        public TransactionZoneToZipArchiveWriter(Encoding encoding)
+        {
+            _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
+        }
+
+        public async Task WriteAsync(ZipArchive archive, RoadNetworkExtractAssemblyRequest request,
+            EditorContext context,
+            CancellationToken cancellationToken)
+        {
+            if (archive == null) throw new ArgumentNullException(nameof(archive));
+            if (request == null) throw new ArgumentNullException(nameof(request));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var dbfEntry = archive.CreateEntry("eTransactiezones.dbf");
+            var dbfHeader = new DbaseFileHeader(
+                DateTime.Now,
+                DbaseCodePage.Western_European_ANSI,
+                new DbaseRecordCount(1),
+                RoadNodeDbaseRecord.Schema
+            );
+            await using (var dbfEntryStream = dbfEntry.Open())
+            using (var dbfWriter =
+                new DbaseBinaryWriter(
+                    dbfHeader,
+                    new BinaryWriter(dbfEntryStream, _encoding, true)))
+            {
+                var dbfRecord = new TransactionZoneDbaseRecord
+                {
+                    SOURCEID = {Value = 1},
+                    TYPE = {Value = 2},
+                    BESCHRIJV =
+                    {
+                        Value =
+                            $"Extract[DownloadId={request.DownloadId.ToGuid():N};RequestId={request.ExternalRequestId.ToString()}]"
+                    },
+                    OPERATOR = {Value = ""},
+                    ORG = {Value = "AGIV"},
+                    APPLICATIE = {Value = "Wegenregister"}
+                };
+                dbfWriter.Write(dbfRecord);
+                dbfWriter.Writer.Flush();
+                await dbfEntryStream.FlushAsync(cancellationToken);
+            }
+
+            var polygon = GeometryTranslator.FromGeometryMultiPolygon(request.Contour);
+            var shapeContent = new PolygonShapeContent(polygon);
+            var shpBoundingBox = BoundingBox3D.FromGeometry(polygon);
+
+            var shpEntry = archive.CreateEntry("eTransactiezones.shp");
+            var shpHeader = new ShapeFileHeader(
+                shapeContent.ContentLength,
+                ShapeType.Polygon,
+                shpBoundingBox);
+            await using (var shpEntryStream = shpEntry.Open())
+            using (var shpWriter =
+                new ShapeBinaryWriter(
+                    shpHeader,
+                    new BinaryWriter(shpEntryStream, _encoding, true)))
+            {
+                shpWriter.Write(shapeContent.RecordAs(RecordNumber.Initial));
+                shpWriter.Writer.Flush();
+                await shpEntryStream.FlushAsync(cancellationToken);
+            }
+
+            var shxEntry = archive.CreateEntry("eTransactiezones.shx");
+            var shxHeader = shpHeader.ForIndex(new ShapeRecordCount(1));
+            await using (var shxEntryStream = shxEntry.Open())
+            using (var shxWriter =
+                new ShapeIndexBinaryWriter(
+                    shxHeader,
+                    new BinaryWriter(shxEntryStream, _encoding, true)))
+            {
+                shxWriter.Write(shapeContent.RecordAs(RecordNumber.Initial).IndexAt(ShapeIndexRecord.InitialOffset));
+                shxWriter.Writer.Flush();
+                await shxEntryStream.FlushAsync(cancellationToken);
+            }
+        }
+    }
+}

--- a/src/RoadRegistry.BackOffice/Extracts/IRoadNetworkExtractArchiveAssembler.cs
+++ b/src/RoadRegistry.BackOffice/Extracts/IRoadNetworkExtractArchiveAssembler.cs
@@ -3,10 +3,9 @@ namespace RoadRegistry.BackOffice.Extracts
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
-    using NetTopologySuite.Geometries;
 
     public interface IRoadNetworkExtractArchiveAssembler
     {
-        Task<MemoryStream> AssembleWithin(MultiPolygon contour, CancellationToken cancellationToken); //Task<(MemoryStream, RoadNetworkRevision)>
+        Task<MemoryStream> AssembleArchive(RoadNetworkExtractAssemblyRequest request, CancellationToken cancellationToken); //Task<(MemoryStream, RoadNetworkRevision)>
     }
 }

--- a/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtractAssemblyRequest.cs
+++ b/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtractAssemblyRequest.cs
@@ -1,0 +1,21 @@
+namespace RoadRegistry.BackOffice.Extracts
+{
+    using System;
+    using NetTopologySuite.Geometries;
+
+    public class RoadNetworkExtractAssemblyRequest
+    {
+        public ExternalExtractRequestId ExternalRequestId { get; }
+        public ExtractRequestId RequestId { get; }
+        public DownloadId DownloadId { get; }
+        public MultiPolygon Contour { get; }
+
+        public RoadNetworkExtractAssemblyRequest(ExternalExtractRequestId requestId, DownloadId downloadId, MultiPolygon contour)
+        {
+            ExternalRequestId = requestId;
+            RequestId = ExtractRequestId.FromExternalRequestId(requestId);
+            DownloadId = downloadId;
+            Contour = contour ?? throw new ArgumentNullException(nameof(contour));
+        }
+    }
+}

--- a/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtractEventModule.cs
+++ b/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtractEventModule.cs
@@ -5,6 +5,7 @@ namespace RoadRegistry.BackOffice.Extracts
     using System.Globalization;
     using System.IO.Compression;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using Be.Vlaanderen.Basisregisters.BlobStore;
     using Core;
     using Framework;
@@ -48,8 +49,11 @@ namespace RoadRegistry.BackOffice.Extracts
                     }
                     else
                     {
-                        var contour = GeometryTranslator.Translate(message.Body.Contour);
-                        using (var content = await assembler.AssembleWithin(contour, ct)) //(content, revision)
+                        var request = new RoadNetworkExtractAssemblyRequest(
+                            new ExternalExtractRequestId(message.Body.ExternalRequestId),
+                            new DownloadId(message.Body.DownloadId),
+                            GeometryTranslator.Translate(message.Body.Contour));
+                        using (var content = await assembler.AssembleArchive(request, ct)) //(content, revision)
                         {
                             content.Position = 0L;
 

--- a/src/RoadRegistry.Editor.Projections/ExtractDownloadRecordProjection.cs
+++ b/src/RoadRegistry.Editor.Projections/ExtractDownloadRecordProjection.cs
@@ -5,7 +5,6 @@ namespace RoadRegistry.Editor.Projections
     using Be.Vlaanderen.Basisregisters.ProjectionHandling.Connector;
     using Be.Vlaanderen.Basisregisters.ProjectionHandling.SqlStreamStore;
     using Microsoft.EntityFrameworkCore;
-    using NodaTime;
     using NodaTime.Text;
     using Schema;
     using Schema.Extracts;

--- a/src/RoadRegistry.Editor.Schema/Extracts/TransactionZoneDbaseRecord.cs
+++ b/src/RoadRegistry.Editor.Schema/Extracts/TransactionZoneDbaseRecord.cs
@@ -1,0 +1,31 @@
+namespace RoadRegistry.Editor.Schema.Extracts
+{
+    using Be.Vlaanderen.Basisregisters.Shaperon;
+
+    public class TransactionZoneDbaseRecord : DbaseRecord
+    {
+        public static readonly TransactionZoneDbaseSchema Schema = new TransactionZoneDbaseSchema();
+
+        public TransactionZoneDbaseRecord()
+        {
+            SOURCEID = new DbaseInt32(Schema.SOURCEID);
+            TYPE = new DbaseInt32(Schema.TYPE);
+            BESCHRIJV = new DbaseString(Schema.BESCHRIJV);
+            OPERATOR = new DbaseString(Schema.OPERATOR);
+            ORG = new DbaseString(Schema.ORG);
+            APPLICATIE = new DbaseString(Schema.APPLICATIE);
+
+            Values = new DbaseFieldValue[]
+            {
+                SOURCEID, TYPE, BESCHRIJV, OPERATOR, ORG, APPLICATIE
+            };
+        }
+
+        public DbaseInt32 SOURCEID { get; }
+        public DbaseInt32 TYPE { get; }
+        public DbaseString BESCHRIJV { get; }
+        public DbaseString OPERATOR { get; }
+        public DbaseString ORG { get; }
+        public DbaseString APPLICATIE { get; }
+    }
+}

--- a/src/RoadRegistry.Editor.Schema/Extracts/TransactionZoneDbaseSchema.cs
+++ b/src/RoadRegistry.Editor.Schema/Extracts/TransactionZoneDbaseSchema.cs
@@ -1,0 +1,42 @@
+namespace RoadRegistry.Editor.Schema.Extracts
+{
+    using Be.Vlaanderen.Basisregisters.Shaperon;
+
+    public class TransactionZoneDbaseSchema : DbaseSchema
+    {
+        public TransactionZoneDbaseSchema()
+        {
+            Fields = new []
+            {
+                DbaseField.CreateNumberField(
+                    new DbaseFieldName(nameof(SOURCEID)),
+                    new DbaseFieldLength(5),
+                    new DbaseDecimalCount(0)),
+                DbaseField.CreateNumberField(
+                    new DbaseFieldName(nameof(TYPE)),
+                    new DbaseFieldLength(5),
+                    new DbaseDecimalCount(0)),
+                DbaseField.CreateCharacterField(
+                    new DbaseFieldName(nameof(BESCHRIJV)),
+                    new DbaseFieldLength(254)),
+                DbaseField.CreateCharacterField(
+                    new DbaseFieldName(nameof(OPERATOR)),
+                    new DbaseFieldLength(254)),
+                DbaseField.CreateCharacterField(
+                    new DbaseFieldName(nameof(ORG)),
+                    new DbaseFieldLength(18)),
+                DbaseField.CreateCharacterField(
+                    new DbaseFieldName(nameof(APPLICATIE)),
+                    new DbaseFieldLength(18))
+            };
+        }
+
+        public DbaseField SOURCEID => Fields[0];
+        public DbaseField TYPE => Fields[1];
+        public DbaseField BESCHRIJV => Fields[2];
+        public DbaseField OPERATOR => Fields[3];
+        public DbaseField ORG => Fields[4];
+        public DbaseField APPLICATIE => Fields[5];
+
+    }
+}


### PR DESCRIPTION
This PR adds:

- Transaction zones to the extract output (based on the extract request)
- Prefixes all files of the extract with an "e"
- Fine tunes the validation messages of the extract api