### PR TITLE
feat: support polygon or multipolygon contour

### DIFF
--- a/src/RoadRegistry.BackOffice.Api/Extracts/DownloadExtractRequestBodyValidator.cs
+++ b/src/RoadRegistry.BackOffice.Api/Extracts/DownloadExtractRequestBodyValidator.cs
@@ -21,7 +21,7 @@ namespace RoadRegistry.BackOffice.Api.Extracts
             RuleFor(c => c.Contour)
                 .NotEmpty().WithMessage("'Contour' must not be empty, null or missing")
                 .Must(BeMultiPolygonGeometryAsWellKnownText)
-                .WithMessage("'Contour' must be a valid multipolygon represented as well-known text")
+                .WithMessage("'Contour' must be a valid multipolygon or polygon represented as well-known text")
                 .When(c => !string.IsNullOrEmpty(c.Contour), ApplyConditionTo.CurrentValidator);
         }
 
@@ -30,12 +30,12 @@ namespace RoadRegistry.BackOffice.Api.Extracts
             try
             {
                 var geometry = _reader.Read(text);
-                if (geometry is MultiPolygon multiPolygon)
+                return geometry switch
                 {
-                    return multiPolygon.IsValid;
-                }
-
-                return false;
+                    MultiPolygon multiPolygon => multiPolygon.IsValid,
+                    Polygon polygon => polygon.IsValid,
+                    _ => false
+                };
             }
             catch (ParseException exception)
             {

--- a/src/RoadRegistry.BackOffice.Api/Extracts/ExtractsController.cs
+++ b/src/RoadRegistry.BackOffice.Api/Extracts/ExtractsController.cs
@@ -70,7 +70,7 @@ namespace RoadRegistry.BackOffice.Api.Extracts
                 {
                     ExternalRequestId = body.RequestId,
                     Contour = GeometryTranslator.TranslateToRoadNetworkExtractGeometry(
-                        (NetTopologySuite.Geometries.MultiPolygon) _reader.Read(body.Contour)),
+                        (NetTopologySuite.Geometries.IPolygonal) _reader.Read(body.Contour)),
                     DownloadId = downloadId
                 });
             await _dispatcher(message, HttpContext.RequestAborted);

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/ContourQueryExtensions.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/ContourQueryExtensions.cs
@@ -14,15 +14,15 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
     // NOTE: If you change the properties of any of the entities used below, you will need to update these queries too!
     public static class ContourQueryExtensions
     {
-        private static SqlParameter ToSqlParameter(this MultiPolygon contour)
+        private static SqlParameter ToSqlParameter(this IPolygonal contour)
         {
             var writer = new SqlServerBytesWriter { IsGeography = false };
-            var bytes = writer.Write(contour);
+            var bytes = writer.Write((Geometry)contour);
             return new SqlParameter("@contour", SqlDbType.Udt) {UdtTypeName = "geometry", SqlValue = new SqlBytes(bytes)};
         }
 
         public static IQueryable<RoadNodeRecord> InsideContour(
-            this DbSet<RoadNodeRecord> source, MultiPolygon contour)
+            this DbSet<RoadNodeRecord> source, IPolygonal contour)
         {
             return source.FromSqlRaw(
                 @"SELECT [node].[Id], [node].[DbaseRecord], [node].[Geometry], [node].[ShapeRecordContent], [node].[ShapeRecordContentLength], [node].[BoundingBox_MaximumX], [node].[BoundingBox_MaximumY], [node].[BoundingBox_MinimumX], [node].[BoundingBox_MinimumY]
@@ -38,7 +38,7 @@ OR [node].[Id] IN (
         }
 
         public static IQueryable<GradeSeparatedJunctionRecord> InsideContour(
-            this DbSet<GradeSeparatedJunctionRecord> source, MultiPolygon contour)
+            this DbSet<GradeSeparatedJunctionRecord> source, IPolygonal contour)
         {
             return source.FromSqlRaw(
                 @"SELECT [junction].[Id], [junction].[DbaseRecord], [junction].[UpperRoadSegmentId], [junction].[LowerRoadSegmentId]
@@ -54,7 +54,7 @@ OR [junction].[LowerRoadSegmentId] IN (
         }
 
         public static IQueryable<RoadSegmentRecord> InsideContour(
-            this DbSet<RoadSegmentRecord> source, MultiPolygon contour)
+            this DbSet<RoadSegmentRecord> source, IPolygonal contour)
         {
             return source.FromSqlRaw(
                 @"SELECT [segment].[Id], [segment].[StartNodeId], [segment].[EndNodeId], [segment].[ShapeRecordContent], [segment].[ShapeRecordContentLength], [segment].[DbaseRecord], [segment].[Geometry], [segment].[BoundingBox_MinimumX], [segment].[BoundingBox_MaximumX], [segment].[BoundingBox_MinimumY], [segment].[BoundingBox_MaximumY], [segment].[BoundingBox_MinimumM],  [segment].[BoundingBox_MaximumM]
@@ -64,7 +64,7 @@ WHERE [segment].[Geometry].STIntersects(@contour) = CAST(1 AS bit)", contour.ToS
 
         public static IQueryable<RoadSegmentEuropeanRoadAttributeRecord> InsideContour(
             this DbSet<RoadSegmentEuropeanRoadAttributeRecord> source,
-            MultiPolygon contour)
+            IPolygonal contour)
         {
             return source.FromSqlRaw(
                 @"SELECT [attribute].[Id], [attribute].[RoadSegmentId], [attribute].[DbaseRecord]
@@ -77,7 +77,7 @@ WHERE [attribute].[RoadSegmentId] IN (
 
         public static IQueryable<RoadSegmentNationalRoadAttributeRecord> InsideContour(
             this DbSet<RoadSegmentNationalRoadAttributeRecord> source,
-            MultiPolygon contour)
+            IPolygonal contour)
         {
             return source.FromSqlRaw(
                 @"SELECT [attribute].[Id], [attribute].[RoadSegmentId], [attribute].[DbaseRecord]
@@ -90,7 +90,7 @@ WHERE [attribute].[RoadSegmentId] IN (
 
         public static IQueryable<RoadSegmentNumberedRoadAttributeRecord> InsideContour(
             this DbSet<RoadSegmentNumberedRoadAttributeRecord> source,
-            MultiPolygon contour)
+            IPolygonal contour)
         {
             return source.FromSqlRaw(
                 @"SELECT [attribute].[Id], [attribute].[RoadSegmentId], [attribute].[DbaseRecord]
@@ -103,7 +103,7 @@ WHERE [attribute].[RoadSegmentId] IN (
 
         public static IQueryable<RoadSegmentLaneAttributeRecord> InsideContour(
             this DbSet<RoadSegmentLaneAttributeRecord> source,
-            MultiPolygon contour)
+            IPolygonal contour)
         {
             return source.FromSqlRaw(
                 @"SELECT [attribute].[Id], [attribute].[RoadSegmentId], [attribute].[DbaseRecord]
@@ -116,7 +116,7 @@ WHERE [attribute].[RoadSegmentId] IN (
 
         public static IQueryable<RoadSegmentWidthAttributeRecord> InsideContour(
             this DbSet<RoadSegmentWidthAttributeRecord> source,
-            MultiPolygon contour)
+            IPolygonal contour)
         {
             return source.FromSqlRaw(
                 @"SELECT [attribute].[Id], [attribute].[RoadSegmentId], [attribute].[DbaseRecord]
@@ -129,7 +129,7 @@ WHERE [attribute].[RoadSegmentId] IN (
 
         public static IQueryable<RoadSegmentSurfaceAttributeRecord> InsideContour(
             this DbSet<RoadSegmentSurfaceAttributeRecord> source,
-            MultiPolygon contour)
+            IPolygonal contour)
         {
             return source.FromSqlRaw(
                 @"SELECT [attribute].[Id], [attribute].[RoadSegmentId], [attribute].[DbaseRecord]

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/PolygonalGeometryTranslator.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/PolygonalGeometryTranslator.cs
@@ -1,0 +1,23 @@
+namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
+{
+    using System;
+    using Be.Vlaanderen.Basisregisters.Shaperon;
+    using Be.Vlaanderen.Basisregisters.Shaperon.Geometries;
+
+    internal static class PolygonalGeometryTranslator
+    {
+        public static Polygon FromGeometry(NetTopologySuite.Geometries.IPolygonal polygonal)
+        {
+            switch (polygonal)
+            {
+                case NetTopologySuite.Geometries.MultiPolygon multiPolygon:
+                    return GeometryTranslator.FromGeometryMultiPolygon(multiPolygon);
+                case NetTopologySuite.Geometries.Polygon polygon:
+                    return GeometryTranslator.FromGeometryPolygon(polygon);
+                default:
+                    throw new InvalidOperationException(
+                        $"The polygonal was expected to be either a Polygon or MultiPolygon. The polygonal was {polygonal.GetType().Name}.");
+            }
+        }
+    }
+}

--- a/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/TransactionZoneToZipArchiveWriter.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/ZipArchiveWriters/TransactionZoneToZipArchiveWriter.cs
@@ -62,7 +62,7 @@ namespace RoadRegistry.BackOffice.ExtractHost.ZipArchiveWriters
                 await dbfEntryStream.FlushAsync(cancellationToken);
             }
 
-            var polygon = GeometryTranslator.FromGeometryMultiPolygon(request.Contour);
+            var polygon = PolygonalGeometryTranslator.FromGeometry(request.Contour);
             var shapeContent = new PolygonShapeContent(polygon);
             var shpBoundingBox = BoundingBox3D.FromGeometry(polygon);
 

--- a/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtract.cs
+++ b/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtract.cs
@@ -43,7 +43,7 @@ namespace RoadRegistry.BackOffice.Extracts
         public static RoadNetworkExtract Request(
             ExternalExtractRequestId externalExtractRequestId,
             DownloadId downloadId,
-            MultiPolygon boundary)
+            IPolygonal contour)
         {
             var instance = Factory();
             instance.Apply(new RoadNetworkExtractGotRequested
@@ -51,12 +51,12 @@ namespace RoadRegistry.BackOffice.Extracts
                 RequestId = ExtractRequestId.FromExternalRequestId(externalExtractRequestId).ToString(),
                 ExternalRequestId = externalExtractRequestId,
                 DownloadId = downloadId,
-                Contour = GeometryTranslator.TranslateToRoadNetworkExtractGeometry(boundary)
+                Contour = GeometryTranslator.TranslateToRoadNetworkExtractGeometry(contour)
             });
             return instance;
         }
 
-        public void RequestAgain(DownloadId downloadId, MultiPolygon boundary)
+        public void RequestAgain(DownloadId downloadId, IPolygonal contour)
         {
             if (!_requestedDownloads.Contains(downloadId))
             {
@@ -65,7 +65,7 @@ namespace RoadRegistry.BackOffice.Extracts
                     RequestId = Id.ToString(),
                     ExternalRequestId = _externalExtractRequestId,
                     DownloadId = downloadId,
-                    Contour = GeometryTranslator.TranslateToRoadNetworkExtractGeometry(boundary)
+                    Contour = GeometryTranslator.TranslateToRoadNetworkExtractGeometry(contour)
                 });
             }
         }

--- a/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtractAssemblyRequest.cs
+++ b/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtractAssemblyRequest.cs
@@ -8,9 +8,9 @@ namespace RoadRegistry.BackOffice.Extracts
         public ExternalExtractRequestId ExternalRequestId { get; }
         public ExtractRequestId RequestId { get; }
         public DownloadId DownloadId { get; }
-        public MultiPolygon Contour { get; }
+        public IPolygonal Contour { get; }
 
-        public RoadNetworkExtractAssemblyRequest(ExternalExtractRequestId requestId, DownloadId downloadId, MultiPolygon contour)
+        public RoadNetworkExtractAssemblyRequest(ExternalExtractRequestId requestId, DownloadId downloadId, IPolygonal contour)
         {
             ExternalRequestId = requestId;
             RequestId = ExtractRequestId.FromExternalRequestId(requestId);

--- a/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtractCommandModule.cs
+++ b/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtractCommandModule.cs
@@ -33,16 +33,16 @@ namespace RoadRegistry.BackOffice.Extracts
                     var externalRequestId = new ExternalExtractRequestId(message.Body.ExternalRequestId);
                     var requestId = ExtractRequestId.FromExternalRequestId(externalRequestId);
                     var downloadId = new DownloadId(message.Body.DownloadId);
-                    var boundary = GeometryTranslator.Translate(message.Body.Contour);
+                    var contour = GeometryTranslator.Translate(message.Body.Contour);
                     var extract = await context.RoadNetworkExtracts.Get(requestId, ct);
                     if (extract == null)
                     {
-                        extract = RoadNetworkExtract.Request(externalRequestId, downloadId, boundary);
+                        extract = RoadNetworkExtract.Request(externalRequestId, downloadId, contour);
                         context.RoadNetworkExtracts.Add(extract);
                     }
                     else
                     {
-                        extract.RequestAgain(downloadId, boundary);
+                        extract.RequestAgain(downloadId, contour);
                     }
                 });
 

--- a/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtractGeometryValidator.cs
+++ b/src/RoadRegistry.BackOffice/Extracts/RoadNetworkExtractGeometryValidator.cs
@@ -7,8 +7,9 @@ namespace RoadRegistry.BackOffice.Extracts
         public RoadNetworkExtractGeometryValidator()
         {
             RuleFor(c => c.SpatialReferenceSystemIdentifier).GreaterThanOrEqualTo(0);
-            RuleFor(c => c.MultiPolygon).NotNull();
-            RuleForEach(c => c.MultiPolygon).NotNull().SetValidator(new PolygonValidator());
+            RuleFor(c => c.MultiPolygon).NotNull().When(c => c.Polygon == null);
+            RuleFor(c => c.Polygon).NotNull().When(c => c.MultiPolygon == null).SetValidator(new PolygonValidator());
+            RuleForEach(c => c.MultiPolygon).NotNull().When(c => c.Polygon == null).SetValidator(new PolygonValidator());
         }
     }
 }

--- a/src/RoadRegistry.BackOffice/Messages/RoadNetworkExtractGeometry.cs
+++ b/src/RoadRegistry.BackOffice/Messages/RoadNetworkExtractGeometry.cs
@@ -4,5 +4,6 @@ namespace RoadRegistry.BackOffice.Messages
     {
         public int SpatialReferenceSystemIdentifier{ get; set; }
         public Polygon[] MultiPolygon { get; set; }
+        public Polygon Polygon { get; set; }
     }
 }

--- a/test/RoadRegistry.Tests/BackOffice/Api/ExtractControllerTests.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Api/ExtractControllerTests.cs
@@ -70,7 +70,7 @@ namespace RoadRegistry.BackOffice.Api
             var response = await controller.PostDownloadRequest(new DownloadExtractRequestBody
             {
                 RequestId = externalExtractRequestId,
-                Contour = writer.Write(BackOffice.GeometryTranslator.Translate(contour))
+                Contour = writer.Write((NetTopologySuite.Geometries.Geometry)BackOffice.GeometryTranslator.Translate(contour))
             });
             var result = Assert.IsType<AcceptedResult>(response);
             Assert.IsType<DownloadExtractResponseBody>(result.Value);
@@ -97,7 +97,7 @@ namespace RoadRegistry.BackOffice.Api
                 await controller.PostDownloadRequest(new DownloadExtractRequestBody
                 {
                     RequestId = null,
-                    Contour = writer.Write(BackOffice.GeometryTranslator.Translate(contour))
+                    Contour = writer.Write((NetTopologySuite.Geometries.Geometry)BackOffice.GeometryTranslator.Translate(contour))
                 });
                 throw new XunitException("Expected a validation exception but did not receive any");
             }

--- a/test/RoadRegistry.Tests/BackOffice/SharedCustomizations.cs
+++ b/test/RoadRegistry.Tests/BackOffice/SharedCustomizations.cs
@@ -341,9 +341,21 @@ namespace RoadRegistry.BackOffice
                 {
                     var geometry = new RoadNetworkExtractGeometry
                     {
-                        MultiPolygon = new []{fixture.Create<Messages.Polygon>()},
-                        SpatialReferenceSystemIdentifier = SpatialReferenceSystemIdentifier.BelgeLambert1972.ToInt32()
+                        SpatialReferenceSystemIdentifier =
+                            SpatialReferenceSystemIdentifier.BelgeLambert1972.ToInt32()
                     };
+
+                    if (generator.Next() % 2 == 0)
+                    {
+                        geometry.MultiPolygon = new[] { fixture.Create<Messages.Polygon>() };
+                        geometry.Polygon = null;
+                    }
+                    else
+                    {
+                        geometry.Polygon = fixture.Create<Messages.Polygon>();
+                        geometry.MultiPolygon = null;
+                    }
+
                     return geometry;
                 }).OmitAutoProperties()
             );
@@ -376,9 +388,21 @@ namespace RoadRegistry.BackOffice
                 {
                     var geometry = new RoadNetworkExtractGeometry
                     {
-                        MultiPolygon = new []{fixture.Create<Messages.Polygon>()},
-                        SpatialReferenceSystemIdentifier = SpatialReferenceSystemIdentifier.BelgeLambert1972.ToInt32()
+                        SpatialReferenceSystemIdentifier =
+                            SpatialReferenceSystemIdentifier.BelgeLambert1972.ToInt32()
                     };
+
+                    if (generator.Next() % 2 == 0)
+                    {
+                        geometry.MultiPolygon = new[] { fixture.Create<Messages.Polygon>() };
+                        geometry.Polygon = null;
+                    }
+                    else
+                    {
+                        geometry.Polygon = fixture.Create<Messages.Polygon>();
+                        geometry.MultiPolygon = null;
+                    }
+
                     return geometry;
                 }).OmitAutoProperties()
             );

--- a/test/RoadRegistry.Tests/Editor/Projections/ExtractDownloadRecordProjectionTests.cs
+++ b/test/RoadRegistry.Tests/Editor/Projections/ExtractDownloadRecordProjectionTests.cs
@@ -37,7 +37,8 @@ namespace RoadRegistry.Editor.Projections
                                     {
                                         SpatialReferenceSystemIdentifier =
                                             SpatialReferenceSystemIdentifier.BelgeLambert1972.ToInt32(),
-                                        MultiPolygon = new BackOffice.Messages.Polygon[0]
+                                        MultiPolygon = new BackOffice.Messages.Polygon[0],
+                                        Polygon = null
                                     },
                                     When = InstantPattern.ExtendedIso.Format(SystemClock.Instance.GetCurrentInstant())
                                 };
@@ -125,7 +126,8 @@ namespace RoadRegistry.Editor.Projections
                             {
                                 SpatialReferenceSystemIdentifier =
                                     SpatialReferenceSystemIdentifier.BelgeLambert1972.ToInt32(),
-                                MultiPolygon = new BackOffice.Messages.Polygon[0]
+                                MultiPolygon = new BackOffice.Messages.Polygon[0],
+                                Polygon = null
                             },
                             When = InstantPattern.ExtendedIso.Format(InstantPattern.ExtendedIso.Parse(available.When).Value)
                         },

--- a/test/RoadRegistry.Tests/Editor/Projections/RoadNetworkChangeFeedProjectionTests.cs
+++ b/test/RoadRegistry.Tests/Editor/Projections/RoadNetworkChangeFeedProjectionTests.cs
@@ -81,7 +81,7 @@ namespace RoadRegistry.Editor.Projections
                     ExternalRequestId = externalExtractRequestId,
                     RequestId = extractRequestId,
                     DownloadId = downloadId,
-                    Contour = new RoadNetworkExtractGeometry { MultiPolygon = Array.Empty<Polygon>(), SpatialReferenceSystemIdentifier = 0 }
+                    Contour = new RoadNetworkExtractGeometry { Polygon = null, MultiPolygon = Array.Empty<Polygon>(), SpatialReferenceSystemIdentifier = 0 }
                 })
                 .Expect(new RoadNetworkChange
                 {


### PR DESCRIPTION
This PR adds support for WR-228, meaning it allows specifying a contour as a _polygon_ in addition to specifying it as (previously only) a _multipolygon_. This was requested by the primary users of the API.