### PR TITLE
fix: check value range of left and right street name

### DIFF
--- a/src/RoadRegistry.BackOffice/Uploads/DbaseFileProblems.cs
+++ b/src/RoadRegistry.BackOffice/Uploads/DbaseFileProblems.cs
@@ -461,6 +461,22 @@ namespace RoadRegistry.BackOffice.Uploads
                 .Build();
         }
 
+        public static FileError LeftStreetNameIdOutOfRange(this IDbaseFileRecordProblemBuilder builder, int value)
+        {
+            return builder
+                .Error(nameof(LeftStreetNameIdOutOfRange))
+                .WithParameter(new ProblemParameter("Actual", value.ToString()))
+                .Build();
+        }
+
+        public static FileError RightStreetNameIdOutOfRange(this IDbaseFileRecordProblemBuilder builder, int value)
+        {
+            return builder
+                .Error(nameof(RightStreetNameIdOutOfRange))
+                .WithParameter(new ProblemParameter("Actual", value.ToString()))
+                .Build();
+        }
+
         // lane
 
         public static FileError LaneCountOutOfRange(this IDbaseFileRecordProblemBuilder builder, int count)

--- a/src/RoadRegistry.BackOffice/Uploads/RoadSegmentChangeDbaseRecordsValidator.cs
+++ b/src/RoadRegistry.BackOffice/Uploads/RoadSegmentChangeDbaseRecordsValidator.cs
@@ -164,6 +164,16 @@ namespace RoadRegistry.BackOffice.Uploads
                                 problems += recordContext.EndRoadNodeIdOutOfRange(record.E_WK_OIDN.Value);
                             }
 
+                            if (record.LSTRNMID.Value.HasValue && !CrabStreetnameId.Accepts(record.LSTRNMID.Value.Value))
+                            {
+                                problems += recordContext.LeftStreetNameIdOutOfRange(record.LSTRNMID.Value.Value);
+                            }
+
+                            if (record.RSTRNMID.Value.HasValue && !CrabStreetnameId.Accepts(record.RSTRNMID.Value.Value))
+                            {
+                                problems += recordContext.RightStreetNameIdOutOfRange(record.RSTRNMID.Value.Value);
+                            }
+
                             if (string.IsNullOrEmpty(record.BEHEERDER.Value))
                             {
                                 problems += recordContext.RequiredFieldIsNull(record.BEHEERDER.Field);

--- a/src/RoadRegistry.Editor.Projections/DutchTranslations/ProblemWithZipArchive.cs
+++ b/src/RoadRegistry.Editor.Projections/DutchTranslations/ProblemWithZipArchive.cs
@@ -141,6 +141,14 @@ namespace RoadRegistry.Editor.Projections.DutchTranslations
                         translation = $"De dbase record {problem.Parameters[0].Value} heeft een ongeldige eind wegknoop in veld {nameof(RoadSegmentChangeDbaseRecord.Schema.E_WK_OIDN)}: {problem.Parameters[1].Value}.";
                         break;
 
+                    case nameof(DbaseFileProblems.LeftStreetNameIdOutOfRange):
+                        translation = $"De dbase record {problem.Parameters[0].Value} heeft een ongeldige straat naam id in veld {nameof(RoadSegmentChangeDbaseRecord.Schema.LSTRNMID)}: {problem.Parameters[1].Value}.";
+                        break;
+
+                    case nameof(DbaseFileProblems.RightStreetNameIdOutOfRange):
+                        translation = $"De dbase record {problem.Parameters[0].Value} heeft een ongeldige straat naam id in veld {nameof(RoadSegmentChangeDbaseRecord.Schema.RSTRNMID)}: {problem.Parameters[1].Value}.";
+                        break;
+
                     case nameof(DbaseFileProblems.OrganizationIdOutOfRange):
                         translation =
                             $"De dbase record {problem.Parameters[0].Value} bevat een ongeldig organisatie identificator in veld {nameof(TransactionZoneDbaseRecord.Schema.ORG)}: {problem.Parameters[1].Value}.";

--- a/test/RoadRegistry.Tests/BackOffice/Uploads/RoadSegmentChangeDbaseRecordsValidatorTests.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Uploads/RoadSegmentChangeDbaseRecordsValidatorTests.cs
@@ -550,6 +550,40 @@ namespace RoadRegistry.BackOffice.Uploads
             Assert.Equal(expectedContext, actualContext);
         }
 
+        [Fact]
+        public void ValidateWithRecordThatHasInvalidLeftStreetNameIdReturnsExpectedResult()
+        {
+            var expectedContext = ZipArchiveValidationContext.Empty;
+            var record = _fixture.Create<RoadSegmentChangeDbaseRecord>();
+            record.LSTRNMID.Value = -12;
+            expectedContext = BuildValidationContext(record, expectedContext);
+            var records = new [] { record }.ToDbaseRecordEnumerator();
+
+            var (result, actualContext) = _sut.Validate(_entry, records, _context);
+
+            Assert.Equal(
+                ZipArchiveProblems.Single(_entry.AtDbaseRecord(new RecordNumber(1)).LeftStreetNameIdOutOfRange(-12)),
+                result);
+            Assert.Equal(expectedContext, actualContext);
+        }
+
+        [Fact]
+        public void ValidateWithRecordThatHasInvalidRightStreetNameIdReturnsExpectedResult()
+        {
+            var expectedContext = ZipArchiveValidationContext.Empty;
+            var record = _fixture.Create<RoadSegmentChangeDbaseRecord>();
+            record.RSTRNMID.Value = -12;
+            expectedContext = BuildValidationContext(record, expectedContext);
+            var records = new [] { record }.ToDbaseRecordEnumerator();
+
+            var (result, actualContext) = _sut.Validate(_entry, records, _context);
+
+            Assert.Equal(
+                ZipArchiveProblems.Single(_entry.AtDbaseRecord(new RecordNumber(1)).RightStreetNameIdOutOfRange(-12)),
+                result);
+            Assert.Equal(expectedContext, actualContext);
+        }
+
         public void Dispose()
         {
             _archive?.Dispose();


### PR DESCRIPTION
This PR addresses the issue raised in issue WR-229, namely that we were missing explicit validation of the value of the right and left street name id.