### PR TITLE
fix: retry after calc chokes on empty seq

### DIFF
--- a/src/RoadRegistry.BackOffice.Api/Extracts/ExtractQueryExtensions.cs
+++ b/src/RoadRegistry.BackOffice.Api/Extracts/ExtractQueryExtensions.cs
@@ -31,7 +31,7 @@ AND (AvailableOn - RequestedOn) <= (
     WHERE Available = 1
     AND (AvailableOn - RequestedOn) <= 3600)
     AND RequestedOn >= {1}", since.ToUnixTimeSeconds(), since.ToUnixTimeSeconds())
-                    .AverageAsync(download => new long?(download.AvailableOn - download.RequestedOn));
+                    .AverageAsync(download => (long?)(download.AvailableOn - download.RequestedOn));
                 if (average.HasValue)
                 {
                     return Convert.ToInt32(average.Value);
@@ -63,7 +63,7 @@ AND (CompletedOn - ReceivedOn) <= (
     WHERE CompletedOn <> 0
     AND (CompletedOn - ReceivedOn) <= 3600)
     AND ReceivedOn >= {1}", since.ToUnixTimeSeconds(), since.ToUnixTimeSeconds())
-                    .AverageAsync(upload => new long?(upload.CompletedOn - upload.ReceivedOn));
+                    .AverageAsync(upload => (long?)(upload.CompletedOn - upload.ReceivedOn));
                 if (average.HasValue)
                 {
                     return Convert.ToInt32(average.Value);

--- a/src/RoadRegistry.BackOffice.Api/Extracts/ExtractsController.cs
+++ b/src/RoadRegistry.BackOffice.Api/Extracts/ExtractsController.cs
@@ -243,7 +243,7 @@ namespace RoadRegistry.BackOffice.Api.Extracts
                 if (record == null)
                 {
                     var retryAfterSeconds =
-                        await context.ExtractUploads.TookAverageAssembleDuration(
+                        await context.ExtractUploads.TookAverageProcessDuration(
                             _clock
                                 .GetCurrentInstant()
                                 .Minus(Duration.FromDays(options.RetryAfterAverageWindowInDays)),
@@ -261,7 +261,7 @@ namespace RoadRegistry.BackOffice.Api.Extracts
                     case ExtractUploadStatus.Received:
                     case ExtractUploadStatus.UploadAccepted:
                         var retryAfterSeconds =
-                            await context.ExtractUploads.TookAverageAssembleDuration(
+                            await context.ExtractUploads.TookAverageProcessDuration(
                                 _clock
                                     .GetCurrentInstant()
                                     .Minus(Duration.FromDays(options.RetryAfterAverageWindowInDays)),


### PR DESCRIPTION
This PR fixes an issue where, when none of the downloads (and this goes for uploads as well) contribute to the average calculation, we end up with an empty sequence, and the `AverageAsync` operator chokes on it. By switching to a nullable variant output of the average, we can circumvent this problem.