### PR TITLE
feat: ack not all changes are extract uploads

### DIFF
--- a/src/RoadRegistry.Editor.Projections/ExtractUploadRecordProjection.cs
+++ b/src/RoadRegistry.Editor.Projections/ExtractUploadRecordProjection.cs
@@ -50,20 +50,32 @@ namespace RoadRegistry.Editor.Projections
 
             When<Envelope<RoadNetworkChangesAccepted>>(async (context, envelope, ct) =>
             {
+                // NOTE: Not all changes to the road network are caused by extract uploads.
+                // Hence why we need to treat this conditionally.
                 var record =
                     context.ExtractUploads.Local.SingleOrDefault(upload => upload.ChangeRequestId == envelope.Message.RequestId)
-                    ?? await context.ExtractUploads.SingleAsync(upload => upload.ChangeRequestId == envelope.Message.RequestId, ct);
-                record.Status = ExtractUploadStatus.ChangesAccepted;
-                record.CompletedOn = InstantPattern.ExtendedIso.Parse(envelope.Message.When).Value.ToUnixTimeSeconds();
+                    ?? await context.ExtractUploads.SingleOrDefaultAsync(upload => upload.ChangeRequestId == envelope.Message.RequestId, ct);
+                if (record != null)
+                {
+                    record.Status = ExtractUploadStatus.ChangesAccepted;
+                    record.CompletedOn = InstantPattern.ExtendedIso.Parse(envelope.Message.When).Value
+                        .ToUnixTimeSeconds();
+                }
             });
 
             When<Envelope<RoadNetworkChangesRejected>>(async (context, envelope, ct) =>
             {
+                // NOTE: Not all changes to the road network are caused by extract uploads.
+                // Hence why we need to treat this conditionally.
                 var record =
                     context.ExtractUploads.Local.SingleOrDefault(upload => upload.ChangeRequestId == envelope.Message.RequestId)
-                    ?? await context.ExtractUploads.SingleAsync(upload => upload.ChangeRequestId == envelope.Message.RequestId, ct);
-                record.Status = ExtractUploadStatus.ChangesRejected;
-                record.CompletedOn = InstantPattern.ExtendedIso.Parse(envelope.Message.When).Value.ToUnixTimeSeconds();
+                    ?? await context.ExtractUploads.SingleOrDefaultAsync(upload => upload.ChangeRequestId == envelope.Message.RequestId, ct);
+                if (record != null)
+                {
+                    record.Status = ExtractUploadStatus.ChangesRejected;
+                    record.CompletedOn = InstantPattern.ExtendedIso.Parse(envelope.Message.When).Value
+                        .ToUnixTimeSeconds();
+                }
             });
         }
     }

--- a/test/RoadRegistry.Tests/Editor/Projections/ExtractUploadRecordProjectionTests.cs
+++ b/test/RoadRegistry.Tests/Editor/Projections/ExtractUploadRecordProjectionTests.cs
@@ -264,6 +264,42 @@ namespace RoadRegistry.Editor.Projections
         }
 
         [Fact]
+        public Task When_changes_got_accepted_but_were_not_caused_by_an_extract_upload()
+        {
+            var uploadId = _fixture.Create<UploadId>();
+
+            _fixture.CustomizeReason();
+            _fixture.CustomizeOperatorName();
+            _fixture.CustomizeOrganizationId();
+            _fixture.CustomizeOrganizationName();
+            _fixture.CustomizeTransactionId();
+            _fixture.Customize<RoadNetworkChangesAccepted>(
+                customization =>
+                    customization
+                        .FromFactory(generator => new RoadNetworkChangesAccepted
+                        {
+                            RequestId = ChangeRequestId.FromUploadId(uploadId),
+                            Reason = _fixture.Create<Reason>(),
+                            Operator = _fixture.Create<OperatorName>(),
+                            OrganizationId = _fixture.Create<OrganizationId>(),
+                            Organization = _fixture.Create<OrganizationName>(),
+                            TransactionId = _fixture.Create<TransactionId>(),
+                            Changes = Array.Empty<AcceptedChange>(),
+                            When = InstantPattern.ExtendedIso.Format(SystemClock.Instance.GetCurrentInstant())
+                        })
+                        .OmitAutoProperties()
+            );
+            var events = _fixture
+                .CreateMany<RoadNetworkChangesAccepted>(1)
+                .ToList();
+
+            return new ExtractUploadRecordProjection()
+                .Scenario()
+                .Given(events)
+                .ExpectNone();
+        }
+
+        [Fact]
         public Task When_changes_got_rejected()
         {
             var uploadId = _fixture.Create<UploadId>();
@@ -327,6 +363,43 @@ namespace RoadRegistry.Editor.Projections
                 .Scenario()
                 .Given(data.SelectMany(d => new object[] { d.given, d.@event }))
                 .Expect(data.Select(d => d.expected));
+        }
+
+        [Fact]
+        public Task When_changes_got_rejected_but_were_not_caused_by_an_extract_upload()
+        {
+            var uploadId = _fixture.Create<UploadId>();
+
+            _fixture.CustomizeReason();
+            _fixture.CustomizeOperatorName();
+            _fixture.CustomizeOrganizationId();
+            _fixture.CustomizeOrganizationName();
+            _fixture.CustomizeTransactionId();
+            _fixture.Customize<RoadNetworkChangesRejected>(
+                customization =>
+                    customization
+                        .FromFactory(generator => new RoadNetworkChangesRejected
+                        {
+                            RequestId = ChangeRequestId.FromUploadId(uploadId),
+                            Reason = _fixture.Create<Reason>(),
+                            Operator = _fixture.Create<OperatorName>(),
+                            OrganizationId = _fixture.Create<OrganizationId>(),
+                            Organization = _fixture.Create<OrganizationName>(),
+                            TransactionId = _fixture.Create<TransactionId>(),
+                            Changes = Array.Empty<RejectedChange>(),
+                            When = InstantPattern.ExtendedIso.Format(SystemClock.Instance.GetCurrentInstant())
+                        })
+                        .OmitAutoProperties()
+            );
+
+            var events = _fixture
+                .CreateMany<RoadNetworkChangesRejected>(1)
+                .ToList();
+
+            return new ExtractUploadRecordProjection()
+                .Scenario()
+                .Given(events)
+                .ExpectNone();
         }
     }
 }


### PR DESCRIPTION
This PR addresses the oversight that not all changes to the road network are caused by extract uploads, i.e. we falsely assumed we could blindly correlate an change to an extract upload. That logic has now been made conditional. It is somewhat concerning that it a side effect caused via the ui also affects the extract api ...