### PR TITLE
feat: improve road network cmd processing speed

### DIFF
--- a/src/RoadRegistry.BackOffice.Api/Program.cs
+++ b/src/RoadRegistry.BackOffice.Api/Program.cs
@@ -213,10 +213,13 @@ namespace RoadRegistry.BackOffice.Api
                                         hostContext.Configuration.GetConnectionString(WellknownConnectionNames.Snapshots)),
                                     WellknownSchemas.SnapshotSchema)),
                             sp.GetService<RecyclableMemoryStreamManager>()))
+
                         .AddSingleton<IRoadNetworkSnapshotReader>(sp =>
                             sp.GetRequiredService<RoadNetworkSnapshotReaderWriter>())
                         .AddSingleton<IRoadNetworkSnapshotWriter>(sp =>
                             sp.GetRequiredService<RoadNetworkSnapshotReaderWriter>())
+                        .AddSingleton(sp =>
+                            new MemoryRoadNetworkSnapshotReaderWriter(sp.GetRequiredService<IRoadNetworkSnapshotReader>()))
                         .AddSingleton(sp => Dispatch.Using(Resolve.WhenEqualToMessage(
                             new CommandHandlerModule[]
                             {
@@ -229,7 +232,8 @@ namespace RoadRegistry.BackOffice.Api
                                 ),
                                 new RoadNetworkCommandModule(
                                     sp.GetService<IStreamStore>(),
-                                    sp.GetService<IRoadNetworkSnapshotReader>(),
+                                    sp.GetService<MemoryRoadNetworkSnapshotReaderWriter>(),
+                                    sp.GetService<MemoryRoadNetworkSnapshotReaderWriter>(),
                                     sp.GetService<IClock>()
                                 ),
                                 new RoadNetworkExtractCommandModule(

--- a/src/RoadRegistry.BackOffice.CommandHost/Program.cs
+++ b/src/RoadRegistry.BackOffice.CommandHost/Program.cs
@@ -199,6 +199,9 @@
                             sp.GetService<RecyclableMemoryStreamManager>()))
                         .AddSingleton<IRoadNetworkSnapshotReader>(sp => sp.GetRequiredService<RoadNetworkSnapshotReaderWriter>())
                         .AddSingleton<IRoadNetworkSnapshotWriter>(sp => sp.GetRequiredService<RoadNetworkSnapshotReaderWriter>())
+                        .AddSingleton(sp =>
+                            new MemoryRoadNetworkSnapshotReaderWriter(
+                                sp.GetRequiredService<IRoadNetworkSnapshotReader>()))
                         .AddSingleton(sp => Dispatch.Using(Resolve.WhenEqualToMessage(
                             new CommandHandlerModule[]
                             {
@@ -211,7 +214,8 @@
                                 ),
                                 new RoadNetworkCommandModule(
                                     sp.GetService<IStreamStore>(),
-                                    sp.GetService<IRoadNetworkSnapshotReader>(),
+                                    sp.GetService<MemoryRoadNetworkSnapshotReaderWriter>(),
+                                    sp.GetService<MemoryRoadNetworkSnapshotReaderWriter>(),
                                     sp.GetService<IClock>()
                                 ),
                                 new RoadNetworkExtractCommandModule(

--- a/src/RoadRegistry.BackOffice/Core/MemoryRoadNetworkSnapshotReaderWriter.cs
+++ b/src/RoadRegistry.BackOffice/Core/MemoryRoadNetworkSnapshotReaderWriter.cs
@@ -1,6 +1,7 @@
 namespace RoadRegistry.BackOffice.Core
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Threading;
     using System.Threading.Tasks;
     using Messages;
@@ -40,9 +41,60 @@ namespace RoadRegistry.BackOffice.Core
 
         public Task WriteSnapshot(RoadNetworkSnapshot snapshot, int version, CancellationToken cancellationToken)
         {
-            Interlocked.CompareExchange(ref _cache,
-                new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version },
-                null);
+            Interlocked.Exchange(ref _cache,
+                new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version });
+            return Task.CompletedTask;
+        }
+
+        private class CachedRoadNetworkSnapshot
+        {
+            public RoadNetworkSnapshot Snapshot { get; set; }
+            public int Version { get; set; }
+        }
+    }
+
+    public class Memory2RoadNetworkSnapshotReaderWriter : IRoadNetworkSnapshotReader, IRoadNetworkSnapshotWriter
+    {
+        private readonly IRoadNetworkSnapshotReader _fallbackReader;
+        private readonly ConcurrentDictionary<int, CachedRoadNetworkSnapshot> _cache;
+
+        // NOTE: For reading we fallback to another snapshot reader
+        // For writing we don't since we don't want to pay serialization and I/O tax nor do we want to deal with possible race conditions (depending on how the roadnetwork command handling is hosted)
+        // Writing new snapshots is still done asynchronously, by a single thread in a single process.
+
+        public Memory2RoadNetworkSnapshotReaderWriter(IRoadNetworkSnapshotReader fallbackReader)
+        {
+            _fallbackReader = fallbackReader ?? throw new ArgumentNullException(nameof(fallbackReader));
+            _cache = new ConcurrentDictionary<int, CachedRoadNetworkSnapshot>();
+        }
+        public async Task<(RoadNetworkSnapshot snapshot, int version)> ReadSnapshot(CancellationToken cancellationToken)
+        {
+            _cache.T
+            if (_cache.TryPeek(out var cached))
+            {
+                return (cached.Snapshot, cached.Version);
+            }
+
+            var (snapshot, version) = await _fallbackReader.ReadSnapshot(cancellationToken);
+            if (snapshot != null)
+            {
+                _cache.Add(new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version });
+                foreach (var item in _cache.ToArray())
+                {
+                    _cache.R
+                }
+                Interlocked.CompareExchange(
+                    ref _cache,
+                    new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version },
+                    null);
+            }
+            return (snapshot, version);
+        }
+
+        public Task WriteSnapshot(RoadNetworkSnapshot snapshot, int version, CancellationToken cancellationToken)
+        {
+            Interlocked.Exchange(ref _cache,
+                new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version });
             return Task.CompletedTask;
         }
 

--- a/src/RoadRegistry.BackOffice/Core/MemoryRoadNetworkSnapshotReaderWriter.cs
+++ b/src/RoadRegistry.BackOffice/Core/MemoryRoadNetworkSnapshotReaderWriter.cs
@@ -1,0 +1,55 @@
+namespace RoadRegistry.BackOffice.Core
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Messages;
+
+    public class MemoryRoadNetworkSnapshotReaderWriter : IRoadNetworkSnapshotReader, IRoadNetworkSnapshotWriter
+    {
+        private readonly IRoadNetworkSnapshotReader _fallbackReader;
+        private CachedRoadNetworkSnapshot _cache;
+
+        // NOTE: For reading we fallback to another snapshot reader
+        // For writing we don't since we don't want to pay serialization and I/O tax nor do we want to deal with possible race conditions (depending on how the roadnetwork command handling is hosted)
+        // Writing new snapshots is still done asynchronously, by a single thread in a single process.
+
+        public MemoryRoadNetworkSnapshotReaderWriter(IRoadNetworkSnapshotReader fallbackReader)
+        {
+            _fallbackReader = fallbackReader ?? throw new ArgumentNullException(nameof(fallbackReader));
+            _cache = null;
+        }
+        public async Task<(RoadNetworkSnapshot snapshot, int version)> ReadSnapshot(CancellationToken cancellationToken)
+        {
+            var cached = Interlocked.CompareExchange(ref _cache, null, null);
+            if (cached != null)
+            {
+                return (cached.Snapshot, cached.Version);
+            }
+
+            var (snapshot, version) = await _fallbackReader.ReadSnapshot(cancellationToken);
+            if (snapshot != null)
+            {
+                Interlocked.CompareExchange(
+                    ref _cache,
+                    new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version },
+                    null);
+            }
+            return (snapshot, version);
+        }
+
+        public Task WriteSnapshot(RoadNetworkSnapshot snapshot, int version, CancellationToken cancellationToken)
+        {
+            Interlocked.CompareExchange(ref _cache,
+                new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version },
+                null);
+            return Task.CompletedTask;
+        }
+
+        private class CachedRoadNetworkSnapshot
+        {
+            public RoadNetworkSnapshot Snapshot { get; set; }
+            public int Version { get; set; }
+        }
+    }
+}

--- a/src/RoadRegistry.BackOffice/Core/MemoryRoadNetworkSnapshotReaderWriter.cs
+++ b/src/RoadRegistry.BackOffice/Core/MemoryRoadNetworkSnapshotReaderWriter.cs
@@ -1,7 +1,6 @@
 namespace RoadRegistry.BackOffice.Core
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Threading;
     using System.Threading.Tasks;
     using Messages;
@@ -31,58 +30,6 @@ namespace RoadRegistry.BackOffice.Core
             var (snapshot, version) = await _fallbackReader.ReadSnapshot(cancellationToken);
             if (snapshot != null)
             {
-                Interlocked.CompareExchange(
-                    ref _cache,
-                    new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version },
-                    null);
-            }
-            return (snapshot, version);
-        }
-
-        public Task WriteSnapshot(RoadNetworkSnapshot snapshot, int version, CancellationToken cancellationToken)
-        {
-            Interlocked.Exchange(ref _cache,
-                new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version });
-            return Task.CompletedTask;
-        }
-
-        private class CachedRoadNetworkSnapshot
-        {
-            public RoadNetworkSnapshot Snapshot { get; set; }
-            public int Version { get; set; }
-        }
-    }
-
-    public class Memory2RoadNetworkSnapshotReaderWriter : IRoadNetworkSnapshotReader, IRoadNetworkSnapshotWriter
-    {
-        private readonly IRoadNetworkSnapshotReader _fallbackReader;
-        private readonly ConcurrentDictionary<int, CachedRoadNetworkSnapshot> _cache;
-
-        // NOTE: For reading we fallback to another snapshot reader
-        // For writing we don't since we don't want to pay serialization and I/O tax nor do we want to deal with possible race conditions (depending on how the roadnetwork command handling is hosted)
-        // Writing new snapshots is still done asynchronously, by a single thread in a single process.
-
-        public Memory2RoadNetworkSnapshotReaderWriter(IRoadNetworkSnapshotReader fallbackReader)
-        {
-            _fallbackReader = fallbackReader ?? throw new ArgumentNullException(nameof(fallbackReader));
-            _cache = new ConcurrentDictionary<int, CachedRoadNetworkSnapshot>();
-        }
-        public async Task<(RoadNetworkSnapshot snapshot, int version)> ReadSnapshot(CancellationToken cancellationToken)
-        {
-            _cache.T
-            if (_cache.TryPeek(out var cached))
-            {
-                return (cached.Snapshot, cached.Version);
-            }
-
-            var (snapshot, version) = await _fallbackReader.ReadSnapshot(cancellationToken);
-            if (snapshot != null)
-            {
-                _cache.Add(new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version });
-                foreach (var item in _cache.ToArray())
-                {
-                    _cache.R
-                }
                 Interlocked.CompareExchange(
                     ref _cache,
                     new CachedRoadNetworkSnapshot { Snapshot = snapshot, Version = version },

--- a/src/RoadRegistry.BackOffice/Core/RoadNetworkCommandModule.cs
+++ b/src/RoadRegistry.BackOffice/Core/RoadNetworkCommandModule.cs
@@ -8,15 +8,16 @@ namespace RoadRegistry.BackOffice.Core
 
     public class RoadNetworkCommandModule : CommandHandlerModule
     {
-        public RoadNetworkCommandModule(IStreamStore store, IRoadNetworkSnapshotReader snapshotReader, IClock clock)
+        public RoadNetworkCommandModule(IStreamStore store, IRoadNetworkSnapshotReader snapshotReader, IRoadNetworkSnapshotWriter snapshotWriter, IClock clock)
         {
             if (store == null) throw new ArgumentNullException(nameof(store));
             if (snapshotReader == null) throw new ArgumentNullException(nameof(snapshotReader));
+            if (snapshotWriter == null) throw new ArgumentNullException(nameof(snapshotWriter));
             if (clock == null) throw new ArgumentNullException(nameof(clock));
 
             For<ChangeRoadNetwork>()
                 .UseValidator(new ChangeRoadNetworkValidator())
-                .UseRoadRegistryContext(store, snapshotReader, EnrichEvent.WithTime(clock))
+                .UseRoadRegistryContext(store, snapshotReader, EnrichEvent.WithTime(clock), snapshotWriter)
                 .Handle(async (context, message, ct) =>
                 {
                     var request = ChangeRequestId.FromString(message.Body.RequestId);

--- a/test/RoadRegistry.Tests/BackOffice/Scenarios/RoadRegistryFixture.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Scenarios/RoadRegistryFixture.cs
@@ -44,6 +44,14 @@ namespace RoadRegistry.BackOffice.Scenarios
             }
         }
 
+        private class FakeRoadNetworkSnapshotWriter : IRoadNetworkSnapshotWriter
+        {
+            public Task WriteSnapshot(RoadNetworkSnapshot snapshot, int version, CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
         private class FakeZipArchiveValidator : IZipArchiveValidator
         {
             public ZipArchiveProblems Validate(ZipArchive archive)
@@ -64,7 +72,7 @@ namespace RoadRegistry.BackOffice.Scenarios
 
             _runner = new ScenarioRunner(
                 Resolve.WhenEqualToMessage(new CommandHandlerModule[] {
-                        new RoadNetworkCommandModule(Store, new FakeRoadNetworkSnapshotReader(), Clock),
+                        new RoadNetworkCommandModule(Store, new FakeRoadNetworkSnapshotReader(), new FakeRoadNetworkSnapshotWriter(), Clock),
                         new RoadNetworkExtractCommandModule(new RoadNetworkExtractUploadsBlobClient(Client), Store, new FakeRoadNetworkSnapshotReader(), ZipArchiveValidator, Clock)
                     }),
                 Store,


### PR DESCRIPTION
This PR improves the road network command processing speed by caching the road network snapshot in memory. Whenever a successful write / append happens to the road network, this cache will be updated with a new snapshot. Effectively reducing the number of roundtrips and the time to create an instance of the road network.

I would test this out in staging and if no noticeable difference, I'd revert these commits. Measuring can happen by comparing the time between upload and accepting / rejecting the changes.