### PR TITLE
fix: better sql timeout handling

### DIFF
--- a/src/RoadRegistry.BackOffice.CommandHost/CommandProcessor.cs
+++ b/src/RoadRegistry.BackOffice.CommandHost/CommandProcessor.cs
@@ -1,6 +1,7 @@
 namespace RoadRegistry.BackOffice.CommandHost
 {
     using System;
+    using System.IO;
     using Microsoft.Data.SqlClient;
     using System.Linq;
     using System.Threading;
@@ -155,9 +156,7 @@ namespace RoadRegistry.BackOffice.CommandHost
                                         logger.LogError(dropped.Exception,
                                             "Subscription was dropped because of a subscriber error.");
 
-                                        if (dropped.Exception != null
-                                            && dropped.Exception is SqlException sqlException
-                                            && sqlException.Number == -2 /* timeout */)
+                                        if (CanResumeFrom(dropped))
                                         {
                                             await scheduler.Schedule(async token =>
                                             {
@@ -197,6 +196,14 @@ namespace RoadRegistry.BackOffice.CommandHost
                     subscription?.Dispose();
                 }
             }, _messagePumpCancellation.Token, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+        }
+
+        private static bool CanResumeFrom(SubscriptionDropped dropped)
+        {
+            const int timeout = -2;
+            return dropped.Exception != null
+                   && (dropped.Exception is SqlException { Number: timeout } ||
+                       dropped.Exception is IOException { InnerException: SqlException { Number: timeout } });
         }
 
         private class Subscribe { }

--- a/src/RoadRegistry.BackOffice.EventHost/EventProcessor.cs
+++ b/src/RoadRegistry.BackOffice.EventHost/EventProcessor.cs
@@ -179,7 +179,7 @@ namespace RoadRegistry.BackOffice.EventHost
                                         logger.LogError(dropped.Exception,
                                             "Subscription was dropped because of a subscriber error");
 
-                                        if (CanResumeFrom(dropped) /* timeout */)
+                                        if (CanResumeFrom(dropped))
                                         {
                                             await scheduler.Schedule(async token =>
                                             {

--- a/src/RoadRegistry.BackOffice.ExtractHost/EventProcessor.cs
+++ b/src/RoadRegistry.BackOffice.ExtractHost/EventProcessor.cs
@@ -1,6 +1,7 @@
 namespace RoadRegistry.BackOffice.ExtractHost
 {
     using System;
+    using System.IO;
     using System.Threading;
     using System.Threading.Channels;
     using System.Threading.Tasks;
@@ -178,9 +179,7 @@ namespace RoadRegistry.BackOffice.ExtractHost
                                         logger.LogError(dropped.Exception,
                                             "Subscription was dropped because of a subscriber error");
 
-                                        if (dropped.Exception != null
-                                            && dropped.Exception is SqlException sqlException
-                                            && sqlException.Number == -2 /* timeout */)
+                                        if (CanResumeFrom(dropped))
                                         {
                                             await scheduler.Schedule(async token =>
                                             {
@@ -220,6 +219,14 @@ namespace RoadRegistry.BackOffice.ExtractHost
                     subscription?.Dispose();
                 }
             }, _messagePumpCancellation.Token, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+        }
+
+        private static bool CanResumeFrom(SubscriptionDropped dropped)
+        {
+            const int timeout = -2;
+            return dropped.Exception != null
+                   && (dropped.Exception is SqlException { Number: timeout } ||
+                       dropped.Exception is IOException { InnerException: SqlException { Number: timeout } });
         }
 
         private class Subscribe { }

--- a/src/RoadRegistry.Editor.ProjectionHost/EventProcessor.cs
+++ b/src/RoadRegistry.Editor.ProjectionHost/EventProcessor.cs
@@ -1,6 +1,7 @@
 namespace RoadRegistry.Editor.ProjectionHost
 {
     using System;
+    using System.IO;
     using System.Threading;
     using System.Threading.Channels;
     using System.Threading.Tasks;
@@ -311,9 +312,7 @@ namespace RoadRegistry.Editor.ProjectionHost
                                         logger.LogError(dropped.Exception,
                                             "Subscription was dropped because of a subscriber error");
 
-                                        if (dropped.Exception != null
-                                            && dropped.Exception is SqlException sqlException
-                                            && sqlException.Number == -2 /* timeout */)
+                                        if (CanResumeFrom(dropped))
                                         {
                                             await scheduler.Schedule(async token =>
                                             {
@@ -347,6 +346,14 @@ namespace RoadRegistry.Editor.ProjectionHost
                     subscription?.Dispose();
                 }
             }, _messagePumpCancellation.Token, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+        }
+
+        private static bool CanResumeFrom(SubscriptionDropped dropped)
+        {
+            const int timeout = -2;
+            return dropped.Exception != null
+                   && (dropped.Exception is SqlException { Number: timeout } ||
+                       dropped.Exception is IOException { InnerException: SqlException { Number: timeout } });
         }
 
         private class Resume { }


### PR DESCRIPTION
This PR is an attempt to better handle timeouts from sql server. Recent logging revealed that the `Microsoft.Data.SqlClient` started throwing a different exception in certain cases, namely, `System.IO.IOException` instead of `Microsoft.Data.SqlClient.SqlException`. The former now seems to wrap the latter.