### PR TITLE
fix: mark nodes that are too close together as a warning instead of an error

### DIFF
--- a/src/RoadRegistry.BackOffice/Core/RoadNodeGeometryTaken.cs
+++ b/src/RoadRegistry.BackOffice/Core/RoadNodeGeometryTaken.cs
@@ -1,6 +1,6 @@
 namespace RoadRegistry.BackOffice.Core
 {
-    public class RoadNodeGeometryTaken : Error
+    public class RoadNodeGeometryTaken : Warning
     {
         public RoadNodeGeometryTaken(RoadNodeId byOtherNode) : base(
             nameof(RoadNodeGeometryTaken),

--- a/test/RoadRegistry.Tests/BackOffice/Scenarios/RoadNetworkScenarios.cs
+++ b/test/RoadRegistry.Tests/BackOffice/Scenarios/RoadNetworkScenarios.cs
@@ -2799,6 +2799,7 @@ namespace RoadRegistry.BackOffice.Scenarios
                                 new Messages.Problem
                                 {
                                     Reason = "RoadNodeGeometryTaken",
+                                    Severity = ProblemSeverity.Warning,
                                     Parameters = new[]
                                     {
                                         new Messages.ProblemParameter
@@ -2939,6 +2940,7 @@ namespace RoadRegistry.BackOffice.Scenarios
                                 new Messages.Problem
                                 {
                                     Reason = "RoadNodeGeometryTaken",
+                                    Severity = ProblemSeverity.Warning,
                                     Parameters = new[]
                                     {
                                         new Messages.ProblemParameter


### PR DESCRIPTION
https://vlaamseoverheid.atlassian.net/browse/WR-276