### PR TITLE
fix: WR-936 singular record TOTPOS with value "0" should be filled in…

### DIFF
--- a/src/RoadRegistry.BackOffice/Uploads/FeatureValidationExtensions.cs
+++ b/src/RoadRegistry.BackOffice/Uploads/FeatureValidationExtensions.cs
@@ -248,7 +248,13 @@ namespace RoadRegistry.BackOffice.Uploads
                                         && problem.Parameters.Count == 2
                                         && problem.Parameters.Any(x => x.Name == "RecordNumber" && x.Value == feature.RecordNumber.ToString())
                                         && problem.Parameters.Any(x => x.Name == "Field" && x.Value == "TOTPOS")
-                                );
+                                )
+                                .Remove(problem =>
+                                    string.Equals(problem.File, problemFile, StringComparison.InvariantCultureIgnoreCase)
+                                        && problem.Reason == nameof(DbaseFileProblems.FromPositionEqualToOrGreaterThanToPosition)
+                                        && problem.Parameters.Any(x => x.Name == "RecordNumber" && x.Value == feature.RecordNumber.ToString())
+                                )
+                                ;
                         }
                     }
                 }

--- a/test/RoadRegistry.BackOffice.ZipArchiveWriters.Tests/BackOffice/BeforeFeatureCompare/Scenarios/Scenarios-RoadSegmentLane.cs
+++ b/test/RoadRegistry.BackOffice.ZipArchiveWriters.Tests/BackOffice/BeforeFeatureCompare/Scenarios/Scenarios-RoadSegmentLane.cs
@@ -39,7 +39,7 @@ public class RoadSegmentLaneScenarios : FeatureCompareTranslatorScenariosBase
     }
 
     [Fact]
-    public async Task ZeroFromPositionShouldGiveProblem()
+    public async Task NonZeroFromPositionShouldGiveProblem()
     {
         var zipArchive = new ExtractsZipArchiveBuilder()
             .WithChange((builder, context) =>
@@ -96,6 +96,19 @@ public class RoadSegmentLaneScenarios : FeatureCompareTranslatorScenariosBase
         var ex = await Assert.ThrowsAsync<ZipArchiveValidationException>(() => TranslateReturnsExpectedResult(zipArchive, TranslatedChanges.Empty));
         var problem = Assert.Single(ex.Problems);
         Assert.Equal(ProblemCode.RoadSegment.Lane.ToPositionNotEqualToLength, problem.Reason);
+    }
+
+    [Fact]
+    public async Task SingleRecordWithZeroToPositionShouldSucceed()
+    {
+        var zipArchive = new ExtractsZipArchiveBuilder()
+            .WithChange((builder, context) =>
+            {
+                builder.TestData.RoadSegment1LaneDbaseRecord.TOTPOS.Value = 0;
+            })
+            .Build();
+
+        await TranslateReturnsExpectedResult(zipArchive, TranslatedChanges.Empty);
     }
 
     [Fact]

--- a/test/RoadRegistry.BackOffice.ZipArchiveWriters.Tests/BackOffice/BeforeFeatureCompare/Scenarios/Scenarios-RoadSegmentSurface.cs
+++ b/test/RoadRegistry.BackOffice.ZipArchiveWriters.Tests/BackOffice/BeforeFeatureCompare/Scenarios/Scenarios-RoadSegmentSurface.cs
@@ -39,7 +39,7 @@ public class RoadSegmentSurfaceScenarios : FeatureCompareTranslatorScenariosBase
     }
 
     [Fact]
-    public async Task ZeroFromPositionShouldGiveProblem()
+    public async Task NonZeroFromPositionShouldGiveProblem()
     {
         var zipArchive = new ExtractsZipArchiveBuilder()
             .WithChange((builder, context) =>
@@ -95,6 +95,19 @@ public class RoadSegmentSurfaceScenarios : FeatureCompareTranslatorScenariosBase
         var ex = await Assert.ThrowsAsync<ZipArchiveValidationException>(() => TranslateReturnsExpectedResult(zipArchive, TranslatedChanges.Empty));
         var problem = Assert.Single(ex.Problems);
         Assert.Equal(ProblemCode.RoadSegment.Surface.ToPositionNotEqualToLength, problem.Reason);
+    }
+
+    [Fact]
+    public async Task SingleRecordWithZeroToPositionShouldSucceed()
+    {
+        var zipArchive = new ExtractsZipArchiveBuilder()
+            .WithChange((builder, context) =>
+            {
+                builder.TestData.RoadSegment1SurfaceDbaseRecord.TOTPOS.Value = 0;
+            })
+            .Build();
+
+        await TranslateReturnsExpectedResult(zipArchive, TranslatedChanges.Empty);
     }
 
     [Fact]

--- a/test/RoadRegistry.BackOffice.ZipArchiveWriters.Tests/BackOffice/BeforeFeatureCompare/Scenarios/Scenarios-RoadSegmentWidth.cs
+++ b/test/RoadRegistry.BackOffice.ZipArchiveWriters.Tests/BackOffice/BeforeFeatureCompare/Scenarios/Scenarios-RoadSegmentWidth.cs
@@ -40,7 +40,7 @@ public class RoadSegmentWidthScenarios : FeatureCompareTranslatorScenariosBase
     }
 
     [Fact]
-    public async Task ZeroFromPositionShouldGiveProblem()
+    public async Task NonZeroFromPositionShouldGiveProblem()
     {
         var zipArchive = new ExtractsZipArchiveBuilder()
             .WithChange((builder, context) =>
@@ -96,6 +96,19 @@ public class RoadSegmentWidthScenarios : FeatureCompareTranslatorScenariosBase
         var ex = await Assert.ThrowsAsync<ZipArchiveValidationException>(() => TranslateReturnsExpectedResult(zipArchive, TranslatedChanges.Empty));
         var problem = Assert.Single(ex.Problems);
         Assert.Equal(ProblemCode.RoadSegment.Width.ToPositionNotEqualToLength, problem.Reason);
+    }
+
+    [Fact]
+    public async Task SingleRecordWithZeroToPositionShouldSucceed()
+    {
+        var zipArchive = new ExtractsZipArchiveBuilder()
+            .WithChange((builder, context) =>
+            {
+                builder.TestData.RoadSegment1WidthDbaseRecord.TOTPOS.Value = 0;
+            })
+            .Build();
+
+        await TranslateReturnsExpectedResult(zipArchive, TranslatedChanges.Empty);
     }
 
     [Fact]


### PR DESCRIPTION
… automatically