### PR TITLE
fix: always keep last coordinate of linestring when removing duplicat…

### DIFF
--- a/src/RoadRegistry.BackOffice/GeometryTranslator.cs
+++ b/src/RoadRegistry.BackOffice/GeometryTranslator.cs
@@ -128,6 +128,11 @@ public static class GeometryTranslator
 
                     if (currentPoint.Equals2D(previousPoint, DefaultTolerances.DuplicateCoordinatesTolerance))
                     {
+                        if (i == lineString.Count - 1)
+                        {
+                            coordinates.Remove(previousPoint);
+                            coordinates.Add(currentPoint);
+                        }
                         continue;
                     }
 

--- a/test/RoadRegistry.Tests/BackOffice/GeometryTranslatorTests.cs
+++ b/test/RoadRegistry.Tests/BackOffice/GeometryTranslatorTests.cs
@@ -185,6 +185,16 @@ public class GeometryTranslatorTests
     }
 
     [Theory]
+    [InlineData("MULTILINESTRING ((0 0, 1.00001 0, 1 0))", "MULTILINESTRING ((0 0, 1 0))")]
+    public void WhenRemovingDuplicateCoordinatesWithinToleranceAtLastTwoCoordinates_ThenEndPointIsKept(string wkt, string expectedWkt)
+    {
+        var geometry = (MultiLineString)new WKTReader().Read(wkt);
+        var wktWithoutDuplicateCoordinates = geometry.WithoutDuplicateCoordinates().AsText();
+
+        Assert.Equal(expectedWkt, wktWithoutDuplicateCoordinates);
+    }
+
+    [Theory]
     [InlineData("MULTILINESTRING ((0 0, 0 0.01, 1 0))")]
     public void WhenRemovingDuplicateCoordinatesOutsideTolerance_ThenNone(string wkt)
     {


### PR DESCRIPTION
…e coordinates