### PR TITLE
fix(2.0): use correct ProgressionId when rebuilding marten projection…

### DIFF
--- a/src/RoadRegistry.Infrastructure.MartenDb/Projections/RoadNetworkChangesConnectedProjection.cs
+++ b/src/RoadRegistry.Infrastructure.MartenDb/Projections/RoadNetworkChangesConnectedProjection.cs
@@ -8,6 +8,8 @@ public abstract class RoadNetworkChangesConnectedProjection : ConnectedProjectio
 {
     private readonly Lazy<ConnectedProjectionHandlerResolver<IDocumentOperations>> _resolver;
 
+    public bool IsCatchingUp { get; internal set; }
+
     protected RoadNetworkChangesConnectedProjection()
     {
         _resolver = new Lazy<ConnectedProjectionHandlerResolver<IDocumentOperations>>(() => Resolve.WhenAssignableToHandlerMessageType(Handlers));

--- a/src/RoadRegistry.Infrastructure.MartenDb/Projections/RoadNetworkChangesProjection.cs
+++ b/src/RoadRegistry.Infrastructure.MartenDb/Projections/RoadNetworkChangesProjection.cs
@@ -14,6 +14,7 @@ public abstract class RoadNetworkChangesProjection : IProjection
     private readonly string _projectionName;
     protected const int DefaultBatchSize = 5000;
     private bool? _isCatchingUp;
+    protected bool IsCatchingUp => _isCatchingUp ?? false;
 
     protected RoadNetworkChangesProjection(IReadOnlyCollection<IRoadNetworkChangesProjection> projections, ILoggerFactory loggerFactory, int batchSize = DefaultBatchSize)
     {
@@ -43,9 +44,10 @@ public abstract class RoadNetworkChangesProjection : IProjection
         try
         {
             var batchCorrelationIds = events.Select(x => x.CorrelationId!).Distinct().ToList();
+            var batchProgressionIds = batchCorrelationIds.Select(BuildProgressionId).ToList();
 
             var processedProjectionProgressions = await operations.Query<RoadNetworkChangesProjectionProgression>()
-                .Where(x => x.ProjectionName == _projectionName && batchCorrelationIds.Contains(x.Id))
+                .Where(x => x.ProjectionName == _projectionName && batchProgressionIds.Contains(x.Id))
                 .ToListAsync(cancellation);
 
             var processOnlyCurrentBatch = DetermineToProcessOnlyCurrentBatch(events);
@@ -90,10 +92,10 @@ public abstract class RoadNetworkChangesProjection : IProjection
             .OrderBy(x => x.First().Sequence)
             .ToList();
 
-        foreach (var eventsGrouping in eventsPerCorrelationId.Select((g, i) => (CorrelationId: g.Key, Events: g.OrderBy(x => x.Sequence).ToList())))
+        foreach (var eventsGrouping in eventsPerCorrelationId.Select((g, _) => (CorrelationId: g.Key, ProgressionId: BuildProgressionId(g.Key), Events: g.OrderBy(x => x.Sequence).ToList())))
         {
             var lastSequenceId = eventsGrouping.Events.Max(x => x.Sequence);
-            var projectionProgression = processedProjectionProgressions.SingleOrDefault(x => x.Id == eventsGrouping.CorrelationId);
+            var projectionProgression = processedProjectionProgressions.SingleOrDefault(x => x.Id == eventsGrouping.ProgressionId);
 
             var eventsToProcess = projectionProgression is not null
                 ? eventsGrouping.Events.Where(x => x.Sequence > projectionProgression.LastSequenceId).ToList()
@@ -102,6 +104,11 @@ public abstract class RoadNetworkChangesProjection : IProjection
             {
                 foreach (var projection in _projections)
                 {
+                    if (projection is RoadNetworkChangesConnectedProjection connected)
+                    {
+                        connected.IsCatchingUp = IsCatchingUp;
+                    }
+
                     await projection.Project(operations, eventsToProcess, cancellation).ConfigureAwait(false);
                 }
             }
@@ -110,7 +117,7 @@ public abstract class RoadNetworkChangesProjection : IProjection
             {
                 operations.Insert(new RoadNetworkChangesProjectionProgression
                 {
-                    Id = $"{_projectionName}-{eventsGrouping.CorrelationId}",
+                    Id = eventsGrouping.ProgressionId,
                     ProjectionName = _projectionName,
                     LastSequenceId = lastSequenceId
                 });
@@ -120,6 +127,11 @@ public abstract class RoadNetworkChangesProjection : IProjection
                 projectionProgression.LastSequenceId = lastSequenceId;
             }
         }
+    }
+
+    private string BuildProgressionId(string correlationId)
+    {
+        return $"{_projectionName}-{correlationId}";
     }
 }
 

--- a/src/RoadRegistry.Read.Projections/GradeSeparatedJunctionReadProjection.cs
+++ b/src/RoadRegistry.Read.Projections/GradeSeparatedJunctionReadProjection.cs
@@ -176,30 +176,42 @@ public class GradeSeparatedJunctionReadProjection : RoadNetworkChangesConnectedP
 
         if (originalRoadSegmentIds.Lower is not null)
         {
-            var roadSegment = roadSegments.SingleOrDefault(x => x.RoadSegmentId == originalRoadSegmentIds.Lower.Value)
-                              ?? throw new InvalidOperationException($"No road segment found for Id {originalRoadSegmentIds.Lower.Value}");
+            var roadSegment = roadSegments.SingleOrDefault(x => x.RoadSegmentId == originalRoadSegmentIds.Lower.Value);
+            if (roadSegment is null)
+            {
+                throw new InvalidOperationException($"No road segment found for Id {originalRoadSegmentIds.Lower.Value}");
+            }
             roadSegment.GradeSeparatedJunctionIds = roadSegment.GradeSeparatedJunctionIds.Except([gradeSeparatedJunctionId]).ToArray();
             session.Store(roadSegment);
         }
         if (originalRoadSegmentIds.Upper is not null)
         {
-            var roadSegment = roadSegments.SingleOrDefault(x => x.RoadSegmentId == originalRoadSegmentIds.Upper.Value)
-                              ?? throw new InvalidOperationException($"No road segment found for Id {originalRoadSegmentIds.Upper.Value}");
+            var roadSegment = roadSegments.SingleOrDefault(x => x.RoadSegmentId == originalRoadSegmentIds.Upper.Value);
+            if (roadSegment is null)
+            {
+                throw new InvalidOperationException($"No road segment found for Id {originalRoadSegmentIds.Upper.Value}");
+            }
             roadSegment.GradeSeparatedJunctionIds = roadSegment.GradeSeparatedJunctionIds.Except([gradeSeparatedJunctionId]).ToArray();
             session.Store(roadSegment);
         }
 
         if (updatedRoadSegmentIds.Lower is not null)
         {
-            var roadSegment = roadSegments.SingleOrDefault(x => x.RoadSegmentId == updatedRoadSegmentIds.Lower.Value)
-                              ?? throw new InvalidOperationException($"No road segment found for Id {updatedRoadSegmentIds.Lower.Value}");
+            var roadSegment = roadSegments.SingleOrDefault(x => x.RoadSegmentId == updatedRoadSegmentIds.Lower.Value);
+            if (roadSegment is null)
+            {
+                throw new InvalidOperationException($"No road segment found for Id {updatedRoadSegmentIds.Lower.Value}");
+            }
             roadSegment.GradeSeparatedJunctionIds = roadSegment.GradeSeparatedJunctionIds.Union([gradeSeparatedJunctionId]).OrderBy(x => x).ToArray();
             session.Store(roadSegment);
         }
         if (updatedRoadSegmentIds.Upper is not null)
         {
-            var roadSegment = roadSegments.SingleOrDefault(x => x.RoadSegmentId == updatedRoadSegmentIds.Upper.Value)
-                              ?? throw new InvalidOperationException($"No road segment found for Id {updatedRoadSegmentIds.Upper.Value}");
+            var roadSegment = roadSegments.SingleOrDefault(x => x.RoadSegmentId == updatedRoadSegmentIds.Upper.Value);
+            if (roadSegment is null)
+            {
+                throw new InvalidOperationException($"No road segment found for Id {updatedRoadSegmentIds.Upper.Value}");
+            }
             roadSegment.GradeSeparatedJunctionIds = roadSegment.GradeSeparatedJunctionIds.Union([gradeSeparatedJunctionId]).OrderBy(x => x).ToArray();
             session.Store(roadSegment);
         }

--- a/src/RoadRegistry.Read.Projections/RoadSegmentReadProjection.cs
+++ b/src/RoadRegistry.Read.Projections/RoadSegmentReadProjection.cs
@@ -11,7 +11,6 @@ using JasperFx.Events;
 using Marten;
 using Newtonsoft.Json;
 using Microsoft.Extensions.Logging;
-using RoadRegistry.Infrastructure;
 using RoadRegistry.Infrastructure.MartenDb.Projections;
 using RoadRegistry.Organization.Events.V2;
 using RoadRegistry.StreetName;
@@ -852,6 +851,11 @@ public class RoadSegmentReadProjection : RoadNetworkChangesConnectedProjection
         if (streetName is not null)
         {
             return streetName.DutchName;
+        }
+
+        if (IsCatchingUp)
+        {
+            return null;
         }
 
         try

--- a/test/RoadRegistry.Projections.Tests/Projections/ReadProjections/FakeStreetNameClient.cs
+++ b/test/RoadRegistry.Projections.Tests/Projections/ReadProjections/FakeStreetNameClient.cs
@@ -11,6 +11,8 @@ public sealed class FakeStreetNameClient : IStreetNameClient
     private readonly Dictionary<int, string> _names = new();
     private Exception? _throwOnGet;
 
+    public bool WasCalled { get; private set; }
+
     public FakeStreetNameClient WithStreetName(int id, string name)
     {
         _names[id] = name;
@@ -25,6 +27,8 @@ public sealed class FakeStreetNameClient : IStreetNameClient
 
     public Task<StreetNameItem?> GetAsync(int id, CancellationToken cancellationToken)
     {
+        WasCalled = true;
+
         if (_throwOnGet is not null)
             throw _throwOnGet;
 

--- a/test/RoadRegistry.Projections.Tests/Projections/ReadProjections/RoadSegmentReadProjectionTests.cs
+++ b/test/RoadRegistry.Projections.Tests/Projections/ReadProjections/RoadSegmentReadProjectionTests.cs
@@ -88,6 +88,34 @@ public class RoadSegmentReadProjectionTests
     }
 
     [Fact]
+    public async Task WhenCatchingUp_ThenStreetNameApiClientIsNotCalled()
+    {
+        var client = new FakeStreetNameClient().WithStreetName(100, "Straat via API");
+        var roadSegmentProjection = new RoadSegmentReadProjection(client, NullLogger<RoadSegmentReadProjection>.Instance)
+        {
+            IsCatchingUp = true
+        };
+        var scenario = new ReadProjectionScenario(
+            new RoadNodeReadProjection(),
+            roadSegmentProjection);
+
+        var segment = _testData.Segment1Added with
+        {
+            StreetNameId = StreetNameAttributeBuilder.Single(_testData.Segment1Added.Geometry, new StreetNameLocalId(100))
+        };
+
+        await scenario.GivenAsync(_testData.Segment1StartNodeAdded, _testData.Segment1EndNodeAdded, segment);
+
+        var stored = await scenario.Load<RoadSegmentReadItem>(1);
+        var dutchName = stored!.StreetNameId.Values
+            .Where(v => v.Value?.StreetNameId == new StreetNameLocalId(100))
+            .Select(v => v.Value!.DutchName)
+            .FirstOrDefault();
+        Assert.Null(dutchName);
+        Assert.False(client.WasCalled);
+    }
+
+    [Fact]
     public async Task WhenStreetNameApiClientThrows_ThenNullIsReturnedAndErrorIsLogged()
     {
         var logger = new CapturingLogger<RoadSegmentReadProjection>();


### PR DESCRIPTION
…s + don't call streetname registry when catching up