### PR TITLE
fix(2.0): start Marten projection daemon via hosted service

### DIFF
--- a/src/RoadRegistry.Projector/Infrastructure/MartenProjectionsDaemonHostedService.cs
+++ b/src/RoadRegistry.Projector/Infrastructure/MartenProjectionsDaemonHostedService.cs
@@ -31,54 +31,55 @@ public sealed class MartenProjectionsDaemonHostedService : IHostedService
         _logger = logger;
     }
 
-public async Task StartAsync(CancellationToken cancellationToken)
-{
-    IProjectionDaemon? daemon = null;
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        IProjectionDaemon? daemon = null;
 
-    try
-    {
-        // Wait for DbUp to finish applying the schema migrations before starting the daemon; otherwise, on a
-        // fresh database, the daemon would fail against not-yet-created tables and never retry.
-        await _migrationsGate.Completed.WaitAsync(cancellationToken);
-        cancellationToken.ThrowIfCancellationRequested();
-
-        daemon = await _store.BuildProjectionDaemonAsync(logger: _logger);
-        await daemon.StartAllAsync();
-
-        _daemon = daemon;
-        daemon = null;
-    }
-    catch (OperationCanceledException)
-    {
-        // Host is shutting down before the migrations completed / daemon started; there is nothing to start.
-    }
-    catch (Exception ex)
-    {
-        _logger.LogError(ex, "Marten projection daemon failed to start");
-    }
-    finally
-    {
-        daemon?.Dispose();
-    }
-}
-
-public async Task StopAsync(CancellationToken cancellationToken)
-{
-    var daemon = Interlocked.Exchange(ref _daemon, null);
-    if (daemon is null)
-    {
-        return;
-    }
-
-    try
-    {
-        if (!cancellationToken.IsCancellationRequested)
+        try
         {
-            await daemon.StopAllAsync();
+            // Wait for DbUp to finish applying the schema migrations before starting the daemon; otherwise, on a
+            // fresh database, the daemon would fail against not-yet-created tables and never retry.
+            await _migrationsGate.Completed.WaitAsync(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            daemon = await _store.BuildProjectionDaemonAsync(logger: _logger);
+            await daemon.StartAllAsync();
+
+            _daemon = daemon;
+            daemon = null;
+        }
+        catch (OperationCanceledException)
+        {
+            // Host is shutting down before the migrations completed / daemon started; there is nothing to start.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Marten projection daemon failed to start");
+        }
+        finally
+        {
+            daemon?.Dispose();
         }
     }
-    finally
+
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
-        daemon.Dispose();
+        var daemon = Interlocked.Exchange(ref _daemon, null);
+        if (daemon is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                await daemon.StopAllAsync();
+            }
+        }
+        finally
+        {
+            daemon.Dispose();
+        }
     }
 }

--- a/src/RoadRegistry.Projector/Infrastructure/MartenProjectionsDaemonHostedService.cs
+++ b/src/RoadRegistry.Projector/Infrastructure/MartenProjectionsDaemonHostedService.cs
@@ -1,0 +1,65 @@
+namespace RoadRegistry.Projector.Infrastructure;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Daemon;
+using Marten;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using RoadRegistry.Infrastructure.MartenDb.Setup;
+
+// Starts the Marten async projection daemon once the schema migrations have been applied. Runs as a hosted service
+// (registered after DatabaseMigrator, so the migrations gate is already completed by the time it starts) instead of
+// being fire-and-forgotten from Startup.Configure. This way it participates in the host lifecycle: the store and gate
+// are injected up front (never resolved from a possibly-disposed provider after an unbounded async gap), a shutdown
+// during startup cancels cleanly, and the daemon is stopped when the host stops.
+public sealed class MartenProjectionsDaemonHostedService : IHostedService
+{
+    private readonly IDocumentStore _store;
+    private readonly DatabaseMigrationsGate _migrationsGate;
+    private readonly ILogger<IProjectionDaemon> _logger;
+    private IProjectionDaemon? _daemon;
+
+    public MartenProjectionsDaemonHostedService(
+        IDocumentStore store,
+        DatabaseMigrationsGate migrationsGate,
+        ILogger<IProjectionDaemon> logger)
+    {
+        _store = store;
+        _migrationsGate = migrationsGate;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Wait for DbUp to finish applying the schema migrations before starting the daemon; otherwise, on a
+            // fresh database, the daemon would fail against not-yet-created tables and never retry.
+            await _migrationsGate.Completed.WaitAsync(cancellationToken);
+
+            _daemon = await _store.BuildProjectionDaemonAsync(logger: _logger);
+            await _daemon.StartAllAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            // Host is shutting down before the migrations completed; there is nothing to start.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Marten projection daemon failed to start");
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_daemon is null)
+        {
+            return;
+        }
+
+        await _daemon.StopAllAsync();
+        _daemon.Dispose();
+    }
+}

--- a/src/RoadRegistry.Projector/Infrastructure/MartenProjectionsDaemonHostedService.cs
+++ b/src/RoadRegistry.Projector/Infrastructure/MartenProjectionsDaemonHostedService.cs
@@ -31,35 +31,54 @@ public sealed class MartenProjectionsDaemonHostedService : IHostedService
         _logger = logger;
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            // Wait for DbUp to finish applying the schema migrations before starting the daemon; otherwise, on a
-            // fresh database, the daemon would fail against not-yet-created tables and never retry.
-            await _migrationsGate.Completed.WaitAsync(cancellationToken);
+public async Task StartAsync(CancellationToken cancellationToken)
+{
+    IProjectionDaemon? daemon = null;
 
-            _daemon = await _store.BuildProjectionDaemonAsync(logger: _logger);
-            await _daemon.StartAllAsync();
-        }
-        catch (OperationCanceledException)
-        {
-            // Host is shutting down before the migrations completed; there is nothing to start.
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Marten projection daemon failed to start");
-        }
+    try
+    {
+        // Wait for DbUp to finish applying the schema migrations before starting the daemon; otherwise, on a
+        // fresh database, the daemon would fail against not-yet-created tables and never retry.
+        await _migrationsGate.Completed.WaitAsync(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        daemon = await _store.BuildProjectionDaemonAsync(logger: _logger);
+        await daemon.StartAllAsync();
+
+        _daemon = daemon;
+        daemon = null;
+    }
+    catch (OperationCanceledException)
+    {
+        // Host is shutting down before the migrations completed / daemon started; there is nothing to start.
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Marten projection daemon failed to start");
+    }
+    finally
+    {
+        daemon?.Dispose();
+    }
+}
+
+public async Task StopAsync(CancellationToken cancellationToken)
+{
+    var daemon = Interlocked.Exchange(ref _daemon, null);
+    if (daemon is null)
+    {
+        return;
     }
 
-    public async Task StopAsync(CancellationToken cancellationToken)
+    try
     {
-        if (_daemon is null)
+        if (!cancellationToken.IsCancellationRequested)
         {
-            return;
+            await daemon.StopAllAsync();
         }
-
-        await _daemon.StopAllAsync();
-        _daemon.Dispose();
+    }
+    finally
+    {
+        daemon.Dispose();
     }
 }

--- a/src/RoadRegistry.Projector/Infrastructure/Startup.cs
+++ b/src/RoadRegistry.Projector/Infrastructure/Startup.cs
@@ -32,7 +32,6 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
 using Be.Vlaanderen.Basisregisters.EventHandling;
 using Be.Vlaanderen.Basisregisters.ProjectionHandling.SqlStreamStore;
 using EventProcessors;
@@ -40,8 +39,6 @@ using Extracts.Projections;
 using Extracts.Schema;
 using Hosts.Infrastructure.Extensions;
 using Integration.Schema;
-using JasperFx.Events.Daemon;
-using Marten;
 using MartenMigration.Projections;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
@@ -124,26 +121,8 @@ public class Startup
                 .MigrateAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        _ = StartMartenProjections(serviceProvider); // Do not await
-    }
-
-    private async Task StartMartenProjections(IServiceProvider sp)
-    {
-        var logger = sp.GetRequiredService<ILogger<IProjectionDaemon>>();
-        try
-        {
-            // Wait for DbUp to finish applying the schema migrations before starting the daemon; otherwise, on a
-            // fresh database, the daemon would fail against not-yet-created tables and never retry.
-            await sp.GetRequiredService<DatabaseMigrationsGate>().Completed;
-
-            var store = sp.GetRequiredService<IDocumentStore>();
-            var projectionDaemon = await store.BuildProjectionDaemonAsync(logger: logger);
-            await projectionDaemon.StartAllAsync();
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Marten projection daemon failed to start");
-        }
+        // The Marten projection daemon is started by MartenProjectionsDaemonHostedService (registered after the
+        // schema migrator), so it runs after the migrations gate completes and within the host lifecycle.
     }
 
     /// <summary>Configures services for the application.</summary>
@@ -301,10 +280,8 @@ public class Startup
                     options.AddRoadNetworkChangesProjection(new RoadNetworkChangesReadProjection(batchSize, sp.GetRequiredService<ILoggerFactory>(), sp.GetRequiredService<IStreetNameClient>()));
                 }
             }).Services
-
-            // Schema owner: apply the versioned SQL migrations (Migrations/*.sql) sequentially via DbUp. Marten no
-            // longer manages schema at startup; this includes the (correlation_id, seq_id) index as a migration file.
             .AddMartenDatabaseMigrations()
+            .AddHostedService<MartenProjectionsDaemonHostedService>() // Must be after MartenDatabaseMigrations
 
             .AddSingleton(new IDbContextMigratorFactory[]
             {


### PR DESCRIPTION
## Problem

On STG the projector logged **"Marten projection daemon failed to start"** with an `ObjectDisposedException` (Autofac lifetime scope already disposed), so the Marten projection daemon never ran.

Root cause: the projector uses the classic `WebHostBuilder`, where `Startup.Configure` runs **before** any `IHostedService`. The daemon was fire-and-forgotten from `Configure`:

```csharp
_ = StartMartenProjections(serviceProvider); // Do not await
```

That method `await`ed the migrations gate (`DatabaseMigrationsGate.Completed`, only completed later by the `DatabaseMigrator` hosted service) and **then** resolved `IDocumentStore` from the captured `serviceProvider`. After that unbounded async gap, a startup/shutdown race could dispose the provider, so `GetRequiredService<IDocumentStore>()` threw. The surrounding `try/catch` logged the error and swallowed it, leaving the daemon silently unstarted.

## Fix

Move daemon startup into a proper hosted service, `MartenProjectionsDaemonHostedService`, registered **immediately after** `AddMartenDatabaseMigrations()`:

- `IDocumentStore`, `DatabaseMigrationsGate` and the logger are **injected up front** — never resolved from a provider after an async delay.
- Hosted-service start order guarantees the migrations gate is already completed (schema exists) by the time the daemon starts — no deadlock, no race.
- It still awaits the gate with the host's `CancellationToken`, no-ops cleanly on `OperationCanceledException` if the host stops mid-startup, and **stops the daemon on host shutdown** via `StopAsync`.

Also removed the dead `StartMartenProjections` method and its orphaned usings from `Startup.cs`.

## Notes

Since the daemon now genuinely starts instead of silently failing, any projection registered on the projector store whose tables are missing from the DbUp baseline would surface as a real daemon error rather than being masked. The projections registered here (`RoadNetworkChangesExtractProjection`, `RoadNetworkChangesReadProjection`) are covered by the baseline.

## Verification

- `dotnet build` of `RoadRegistry.Projector` succeeds (0 errors).
- Redeploy to STG and confirm the daemon starts (no "Marten projection daemon failed to start" log) and projections advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
